### PR TITLE
Use `sql` instead of `capture`

### DIFF
--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/BooleanLiteralTestDialect.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/BooleanLiteralTestDialect.kt
@@ -1,7 +1,7 @@
 package io.exoquery
 
-import io.exoquery.sql.BooleanLiteralSupport
-import io.exoquery.sql.SqlIdiom
+import io.exoquery.lang.BooleanLiteralSupport
+import io.exoquery.lang.SqlIdiom
 import io.exoquery.util.TraceConfig
 import io.exoquery.util.Tracer
 

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/BuildFor.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/BuildFor.kt
@@ -3,10 +3,7 @@ package io.exoquery
 import io.exoquery.annotation.ExoBuildDatabaseSpecific
 import io.exoquery.annotation.ExoBuildFunctionLabel
 import io.exoquery.annotation.ExoBuildRoomSpecific
-import io.exoquery.sql.GenericDialect
-import io.exoquery.sql.MySqlDialect
-import io.exoquery.sql.PostgresDialect
-import io.exoquery.sql.SqlServerDialect
+import io.exoquery.lang.GenericDialect
 
 interface BuildFor<T> {
   @ExoBuildDatabaseSpecific(PostgresDialect::class)

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/H2Dialect.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/H2Dialect.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.SqlIdiom
+import io.exoquery.lang.SqlIdiom
 import io.exoquery.util.TraceConfig
 import io.exoquery.util.Tracer
 
@@ -10,7 +10,7 @@ import io.exoquery.util.Tracer
  * TODO the only major difference with the standard SqlIdiom/Postgres is on-conflict rendering,
  *      need to add then when OnConflict is implemented.
  */
-class H2Dialect(override val traceConf: TraceConfig = TraceConfig.empty) : SqlIdiom {
+open class H2Dialect(override val traceConf: TraceConfig = TraceConfig.empty) : SqlIdiom {
   override val concatFunction: String = "||"
   override val useActionTableAliasAs = SqlIdiom.ActionTableAliasBehavior.UseAs
   override val reservedKeywords: Set<String> = setOf(

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/Param.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/Param.kt
@@ -5,23 +5,23 @@ import kotlin.reflect.KClass
 
 
 /*
- * val expr: @Captured SqlExpression<Int> = capture { foo + bar }
- * val query: SqlQuery<Person> = capture { Table<Person>() }
- * val query2: SqlQuery<Int> = capture { query.map { p -> p.age } }
+ * val expr: @Captured SqlExpression<Int> = sql { foo + bar }
+ * val query: SqlQuery<Person> = sql { Table<Person>() }
+ * val query2: SqlQuery<Int> = sql { query.map { p -> p.age } }
  *
  * so:
  * // Capturing a generic expression returns a SqlExpression
- * fun <T> capture(block: () -> T): SqlExpression<T>
+ * fun <T> sql(block: () -> T): SqlExpression<T>
  * for example:
  * {{{
- * val combo: SqlExpression<Int> = capture { foo + bar }
+ * val combo: SqlExpression<Int> = sql { foo + bar }
  * }}}
  *
  * // Capturing a SqlQuery returns a SqlQuery
- * fun <T> capture(block: () -> SqlQuery<T>): SqlQuery<T>
+ * fun <T> sql(block: () -> SqlQuery<T>): SqlQuery<T>
  * for example:
  * {{{
- * val query: SqlQuery<Person> = capture { Table<Person>() }
+ * val query: SqlQuery<Person> = sql { Table<Person>() }
  * }}}
  */
 sealed interface Param<T : Any> {
@@ -56,7 +56,7 @@ data class ParamSingle<T : Any>(override val id: BID, val value: T?, override va
 }
 
 /**
- * For capture.batch { param -> insert { set(name = param(p.name <- encoding the value here!)) }  }
+ * For sql.batch { param -> insert { set(name = param(p.name <- encoding the value here!)) }  }
  */
 data class ParamBatchRefiner<Input, Output : Any>(override val id: BID, val refiner: (Input?) -> Output?, override val serial: ParamSerializer<Output>, override val description: String? = null) : Param<Output> {
   fun refine(input: Input): ParamSingle<Output> = ParamSingle<Output>(id, refiner(input), serial, description)

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/SqlAction.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/SqlAction.kt
@@ -4,7 +4,7 @@ import io.exoquery.annotation.CapturedDynamic
 import io.exoquery.annotation.ExoBuildFunctionLabel
 import io.exoquery.annotation.ExoInternal
 import io.exoquery.printing.PrintMisc
-import io.exoquery.sql.SqlIdiom
+import io.exoquery.lang.SqlIdiom
 import io.exoquery.xr.RuntimeBuilder
 import io.exoquery.xr.XR
 import io.exoquery.xr.toActionKind

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/SqlCompiledQuery.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/SqlCompiledQuery.kt
@@ -1,10 +1,10 @@
 package io.exoquery
 
 import io.exoquery.printing.PrintMisc
-import io.exoquery.sql.ParamBatchTokenRealized
-import io.exoquery.sql.SqlQueryModel
-import io.exoquery.sql.StatelessTokenTransformer
-import io.exoquery.sql.Token
+import io.exoquery.lang.ParamBatchTokenRealized
+import io.exoquery.lang.SqlQueryModel
+import io.exoquery.lang.StatelessTokenTransformer
+import io.exoquery.lang.Token
 import io.exoquery.xr.XR
 
 sealed interface Phase {
@@ -28,7 +28,7 @@ sealed interface ActionKind {
  * ```
  * val ds: DataSource = ...
  * val controller = JdbcControllers.Postgres(ds)
- * val myQuery: SqlQuery<Person> = capture { Table<Person>().filter { p -> p.name == "Joe" } }
+ * val myQuery: SqlQuery<Person> = sql { Table<Person>().filter { p -> p.name == "Joe" } }
  * val result: List<Person> = myQuery.buildFor.Postgres().runOn(controller)
  * ```
  */

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/SqlQuery.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/SqlQuery.kt
@@ -5,7 +5,7 @@ import io.exoquery.annotation.ExoBuildFunctionLabel
 import io.exoquery.annotation.ExoInternal
 import io.exoquery.norm.NormalizeCustomQueries
 import io.exoquery.printing.PrintMisc
-import io.exoquery.sql.SqlIdiom
+import io.exoquery.lang.SqlIdiom
 import io.exoquery.xr.RuntimeBuilder
 import io.exoquery.xr.XR
 

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/SqliteDialect.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/SqliteDialect.kt
@@ -1,13 +1,13 @@
 package io.exoquery
 
-import io.exoquery.sql.*
+import io.exoquery.lang.*
 import io.exoquery.util.TraceConfig
 import io.exoquery.util.Tracer
 import io.exoquery.util.stmt
 import io.exoquery.util.unaryPlus
 import io.exoquery.xr.XR
 
-class SqliteDialect(override val traceConf: TraceConfig = TraceConfig.Companion.empty) : SqlIdiom, BooleanLiteralSupport {
+open class SqliteDialect(override val traceConf: TraceConfig = TraceConfig.Companion.empty) : SqlIdiom, BooleanLiteralSupport {
   override val concatFunction: String = "||"
   override val useActionTableAliasAs = SqlIdiom.ActionTableAliasBehavior.UseAs
   override val trace: Tracer by lazy { Tracer(traceType, traceConf, 1) }

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/Unpack.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/Unpack.kt
@@ -2,7 +2,7 @@ package io.exoquery
 
 import io.exoquery.annotation.ExoInternal
 import io.exoquery.generation.Code
-import io.exoquery.sql.SqlQueryModel
+import io.exoquery.lang.SqlQueryModel
 import io.exoquery.xr.EncodingXR
 import io.exoquery.xr.XR
 import kotlinx.serialization.decodeFromHexString

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/annotation/Annotations.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/annotation/Annotations.kt
@@ -1,7 +1,7 @@
 package io.exoquery.annotation
 
 import io.exoquery.serial.ParamSerializer
-import io.exoquery.sql.SqlIdiom
+import io.exoquery.lang.SqlIdiom
 import io.exoquery.util.TraceType
 import kotlin.reflect.KClass
 
@@ -135,7 +135,7 @@ sealed interface ParamKind {
   }
 }
 
-// Using annotations to identify what functions capture queries/expressions/etc...
+// Using annotations to identify what functions sql queries/expressions/etc...
 // instead of parsing them by name is a more flexible approach.
 @ExoInternal
 @Target(AnnotationTarget.FUNCTION)

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/annotation/UserAnnotations.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/annotation/UserAnnotations.kt
@@ -8,7 +8,7 @@ package io.exoquery.annotation
  * ```
  * data class MyDate(val year: Int, val month: Int, val day: Int)
  * data class Customer(name: String, lastOrder: MyDate)
- * capture { Table<Customer>() }
+ * sql { Table<Customer>() }
  * // Would be broken down into something like:
  * // SELECT name, lastOrder_year, lastOrder_month, lastOrder_day FROM Customer
  * // However, if we annotate MyDate with ExoValue i.e. data class `Customer(name: String, lastOrder: @ExoValue MyDate)`
@@ -34,8 +34,8 @@ annotation class ExoValue
  * Use it like this:
  * ```
  * data class Person(@ExoField("first_name") val firstName: String, @ExoField("last_name") val lastName: String)
- * // Then when you capture a query like:
- * capture { Table<Person>().filter { it.firstName == "Joe" }
+ * // Then when you sql a query like:
+ * sql { Table<Person>().filter { it.firstName == "Joe" }
  * // It will come out as:
  * // SELECT first_name, last_name FROM Person WHERE first_name = 'Joe'
  * ```

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/codegen/model/DatabaseTypes.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/codegen/model/DatabaseTypes.kt
@@ -1,6 +1,6 @@
 package io.exoquery.codegen.model
 
-import io.exoquery.sql.SqlIdiom
+import io.exoquery.lang.SqlIdiom
 import kotlin.reflect.KClass
 
 // Kotlin:

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/codegen/util/RegexTransformGroups.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/codegen/util/RegexTransformGroups.kt
@@ -2,7 +2,7 @@ package io.exoquery.codegen.util
 
 
 /**
- * TODO use this in the NameParser.UsingRegex in order to be able to transform capture groups
+ * TODO use this in the NameParser.UsingRegex in order to be able to transform sql groups
  *      in custom ways e.g. to uppercase.
  */
 fun transformGroups(

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/generation/CodeGenDsl.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/generation/CodeGenDsl.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.Serializable as Ser
 
 /*
 
-capture.generate(
+sql.generate(
   TableClasses(
     codeVersion = "1.0.0",
     driver = DatabaseDriver.Postgres,

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/BooleanLiteralSupport.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/BooleanLiteralSupport.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.xr.BetaReduction
 import io.exoquery.xr.XR

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/DialectBehaviors.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/DialectBehaviors.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 sealed interface EqualityBehavior {
   object AnsiEquality : EqualityBehavior

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/ExpandNestedQueries.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/ExpandNestedQueries.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.decomat.*
 import io.exoquery.xr.*

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/GenericDialect.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/GenericDialect.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.util.TraceConfig
 import io.exoquery.util.Tracer

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/MirrorIdiom.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/MirrorIdiom.kt
@@ -1,6 +1,6 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
-import io.exoquery.sql.mkStmt
+import io.exoquery.lang.mkStmt
 import io.exoquery.util.interleaveWith
 import io.exoquery.util.stmt
 import io.exoquery.xr.AggregationOperator

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/MySqlDialect.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/MySqlDialect.kt
@@ -1,6 +1,7 @@
-package io.exoquery.sql
+package io.exoquery
 
-import io.exoquery.sql.SqlIdiom.Companion.DefaultMethodMappings
+import io.exoquery.lang.*
+import io.exoquery.lang.SqlIdiom.Companion.DefaultMethodMappings
 import io.exoquery.util.TraceConfig
 import io.exoquery.util.Tracer
 import io.exoquery.util.unaryPlus
@@ -9,7 +10,7 @@ import io.exoquery.xr.OP
 import io.exoquery.xr.XR
 import io.exoquery.xrError
 
-class MySqlDialect(override val traceConf: TraceConfig = TraceConfig.empty) : SqlIdiom {
+open class MySqlDialect(override val traceConf: TraceConfig = TraceConfig.empty) : SqlIdiom {
   override val useActionTableAliasAs = SqlIdiom.ActionTableAliasBehavior.UseAs
 
   override val trace: Tracer by lazy { Tracer(traceType, traceConf, 1) }

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/PostgresDialect.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/PostgresDialect.kt
@@ -1,12 +1,13 @@
-package io.exoquery.sql
+package io.exoquery
 
+import io.exoquery.lang.*
 import io.exoquery.util.TraceConfig
 import io.exoquery.util.Tracer
 import io.exoquery.xr.BetaReduction
 import io.exoquery.xr.BetaReduction.Companion.invoke
 import io.exoquery.xr.XR
 
-class PostgresDialect(override val traceConf: TraceConfig = TraceConfig.Companion.empty) : SqlIdiom {
+open class PostgresDialect(override val traceConf: TraceConfig = TraceConfig.Companion.empty) : SqlIdiom {
   override val useActionTableAliasAs = SqlIdiom.ActionTableAliasBehavior.UseAs
   override val reservedKeywords: Set<String> = setOf(
     "all",

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/PropertyMatroyshka.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/PropertyMatroyshka.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.decomat.*
 import io.exoquery.xr.XR

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/QueryLevel.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/QueryLevel.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.xr.XRType
 

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/RemoveExtraAlias.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/RemoveExtraAlias.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.xr.XR
 

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/Renderer.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/Renderer.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.BID
 import io.exoquery.Param

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SelectPropertyProtractor.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SelectPropertyProtractor.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.decomat.*
 import io.exoquery.xr.XRType

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlIdiom.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlIdiom.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.decomat.*
 import io.exoquery.printing.HasPhasePrinting

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlNormalize.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlNormalize.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.norm.AvoidAliasConflictApply
 import io.exoquery.norm.ExpandProductNullChecks

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlQueryHelper.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlQueryHelper.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.xr.BetaReduction
 import io.exoquery.xr.XR

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlQueryHelpers.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlQueryHelpers.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.decomat.Is
 import io.decomat.Pattern

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlQueryModel.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlQueryModel.kt
@@ -1,9 +1,9 @@
 @file:Suppress("NAME_SHADOWING", "NAME_SHADOWING")
 
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.printing.PrintXR
-import io.exoquery.sql.SqlQueryHelper.flattenDualHeadsIfPossible
+import io.exoquery.lang.SqlQueryHelper.flattenDualHeadsIfPossible
 import io.exoquery.util.Globals
 import io.exoquery.util.TraceConfig
 import io.exoquery.util.TraceType
@@ -95,7 +95,7 @@ sealed interface SqlQueryModel {
 
   fun show(pretty: Boolean = false): String {
     val str =
-      with(PostgresDialect(Globals.traceConfig())) {
+      with(io.exoquery.PostgresDialect(Globals.traceConfig())) {
         this@SqlQueryModel.token.toString()
       }
     // TODO integrate formatter via `expect`
@@ -716,7 +716,7 @@ class SqlQueryApply(val traceConfig: TraceConfig) {
 
           // ===== The following have special handling in source function =====
           // Constructs like Map(FlatFilter(...),id,output) rely on this because we treat `output` as ExprToQuery(output) in the
-          // `flatten` function above. Also constructs situations like `capture.select { 1 }`.
+          // `flatten` function above. Also constructs situations like `sql.select { 1 }`.
           is XR.ExprToQuery -> FlattenSqlQuery(from = sources, select = listOf(SelectValue(head)), type = type)
           is XR.Free -> FlattenSqlQuery(from = sources + source(this, alias.name), select = select(alias.name, type, loc), type = type)
           is XR.Nested -> FlattenSqlQuery(from = sources + source(this, alias.name), select = select(alias.name, type, loc), type = type)

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlServerDialect.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlServerDialect.kt
@@ -1,5 +1,6 @@
-package io.exoquery.sql
+package io.exoquery
 
+import io.exoquery.lang.*
 import io.exoquery.ActionKind
 import io.exoquery.util.TraceConfig
 import io.exoquery.util.Tracer
@@ -10,7 +11,7 @@ import io.exoquery.xr.BinaryOperator
 import io.exoquery.xr.OP
 import io.exoquery.xr.toActionKind
 
-class SqlServerDialect(override val traceConf: TraceConfig = TraceConfig.empty) : SqlIdiom, BooleanLiteralSupport {
+open class SqlServerDialect(override val traceConf: TraceConfig = TraceConfig.empty) : SqlIdiom, BooleanLiteralSupport {
   override val concatFunction: String = "+"
   override val useActionTableAliasAs = SqlIdiom.ActionTableAliasBehavior.UseAs
   override val trace: Tracer by lazy { Tracer(traceType, traceConf, 1) }

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/StatelessQueryTransformer.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/StatelessQueryTransformer.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.xr.XRType
 

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/StatelessTokenTransformer.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/StatelessTokenTransformer.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 interface StatelessTokenTransformer {
   fun invoke(token: Token): Token =

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/Token.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/Token.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.BID
 import io.exoquery.Param

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/UnnestProperty.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/UnnestProperty.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.xr.XR
 import io.exoquery.xr.XR.*

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/ValueizeSingleLeafSelects.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/ValueizeSingleLeafSelects.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.xr.StatelessTransformer
 import io.exoquery.xr.XR

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/VendorizeBooleans.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/VendorizeBooleans.kt
@@ -1,4 +1,4 @@
-package io.exoquery.sql
+package io.exoquery.lang
 
 import io.exoquery.xr._EqEq_
 import io.exoquery.xr._And_

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/norm/AdHocReduction.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/norm/AdHocReduction.kt
@@ -21,7 +21,7 @@ class AdHocReduction(val traceConfig: TraceConfig) {
    * ```
    * You cannot use this pattern if the body of the FlatMap has a head that is a FlatJoin. For example:
    * ```
-   * capture {
+   * sql {
    *   select {
    *     val p = from(Table<Person>())
    *     val a = joinLeft(Table<Address>()) { it.ownerId == p.id }
@@ -32,7 +32,7 @@ class AdHocReduction(val traceConfig: TraceConfig) {
    *
    * Same kind of thing if there is a flatFilter
    * ```
-   * capture.select {
+   * sql.select {
    *   val p = from(Table<Person>())
    *   where { p.age > 18 }
    *   p

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/norm/ExpandProductNullChecks.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/norm/ExpandProductNullChecks.kt
@@ -1,7 +1,7 @@
 package io.exoquery.norm
 
 import io.decomat.*
-import io.exoquery.sql.ProtractQuat
+import io.exoquery.lang.ProtractQuat
 import io.exoquery.xr._NotEq_
 import io.exoquery.xr._And_
 import io.exoquery.xr.EqEq

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/norm/SymbolicReduction.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/norm/SymbolicReduction.kt
@@ -83,7 +83,7 @@ class SymbolicReduction(val traceConfig: TraceConfig) {
          * FlatMap(ent, FlatMap(Map(FlatJoin), Map(FlatJoin)) then you will have a problem because the FlatJoin in the
          * head and body positions of the inner FlatMap. Therefore we need to check that the head and body of the outer FlatMap do not have both have
          * flatJoins in order to proceed with this transformation.
-         * (**) This is typically produced by using a capture.select clause, see "variable deconstruction should work even when passed to further join" in
+         * (**) This is typically produced by using a sql.select clause, see "variable deconstruction should work even when passed to further join" in
          * VariableReductionReq.kt for an example. Also the MonadicMachinerReq has lots of examples of this.
          *
          * The only exception to this rule if the head of the inner FlatMap has a XR.Map in the tail position (which is actually the most common case).

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/norm/verify/FreeVariables.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/norm/verify/FreeVariables.kt
@@ -36,7 +36,7 @@ data class State(val seen: Set<IdentName>, val free: Set<IdentName>) {
 
 fun XR.Ident.asIdName(): IdentName = IdentName(this.name, this)
 
-// Not sure if this check is actually necessary because in the parse has detects with GetValue instances come from inside and outside the capture block
+// Not sure if this check is actually necessary because in the parse has detects with GetValue instances come from inside and outside the sql block
 data class FreeVariables(override val state: State) : StatefulTransformer<State> {
   override fun invoke(xr: XR.Expression): Pair<XR.Expression, StatefulTransformer<State>> =
     when {

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/norm/verify/VerifySqlQuery.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/norm/verify/VerifySqlQuery.kt
@@ -1,7 +1,7 @@
 package io.exoquery.norm.verify
 
 import io.exoquery.norm.verify.FreeVariables.Companion.invoke
-import io.exoquery.sql.*
+import io.exoquery.lang.*
 import io.exoquery.xr.XR
 
 class VerifySqlQuery {

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/printing/HasPhasePrinting.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/printing/HasPhasePrinting.kt
@@ -1,6 +1,6 @@
 package io.exoquery.printing
 
-import io.exoquery.sql.SqlQueryModel
+import io.exoquery.lang.SqlQueryModel
 import io.exoquery.util.TraceConfig
 import io.exoquery.util.TraceType
 import io.exoquery.util.Tracer

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/printing/PrintXR.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/printing/PrintXR.kt
@@ -16,17 +16,17 @@ import io.exoquery.kmp.pprint.PPrinter
 import io.exoquery.kmp.pprint.PPrinterManual
 import io.exoquery.pprint.PPrinterConfig
 import io.exoquery.pprint.Tree
-import io.exoquery.sql.ParamBatchToken
-import io.exoquery.sql.ParamBatchTokenRealized
-import io.exoquery.sql.ParamMultiToken
-import io.exoquery.sql.ParamMultiTokenRealized
-import io.exoquery.sql.ParamSingleToken
-import io.exoquery.sql.ParamSingleTokenRealized
-import io.exoquery.sql.SetContainsToken
-import io.exoquery.sql.Statement
-import io.exoquery.sql.StringToken
-import io.exoquery.sql.Token
-import io.exoquery.sql.TokenContext
+import io.exoquery.lang.ParamBatchToken
+import io.exoquery.lang.ParamBatchTokenRealized
+import io.exoquery.lang.ParamMultiToken
+import io.exoquery.lang.ParamMultiTokenRealized
+import io.exoquery.lang.ParamSingleToken
+import io.exoquery.lang.ParamSingleTokenRealized
+import io.exoquery.lang.SetContainsToken
+import io.exoquery.lang.Statement
+import io.exoquery.lang.StringToken
+import io.exoquery.lang.Token
+import io.exoquery.lang.TokenContext
 import io.exoquery.util.ShowTree
 import io.exoquery.xr.*
 import kotlinx.serialization.SerializationStrategy
@@ -74,7 +74,7 @@ class PrintMisc(config: PPrinterConfig = PPrinterConfig()) : PPrinterManual<Any?
     when (x) {
       is XR -> PrintXR(XR.serializer(), config.copy(defaultShowFieldNames = false)).treeifyThis(x, elementName)
       is XRType -> PrintXR(XRType.serializer(), config).treeifyThis(x, elementName)
-      is io.exoquery.sql.SqlQueryModel -> PrintXR(io.exoquery.sql.SqlQueryModel.serializer(), config).treeifyThis(x, elementName)
+      is io.exoquery.lang.SqlQueryModel -> PrintXR(io.exoquery.lang.SqlQueryModel.serializer(), config).treeifyThis(x, elementName)
       is SqlExpression<*> -> Tree.Apply("SqlExpression", iteratorOf(treeifyThis(x.xr, "xr"), treeifyThis(x.runtimes, "runtimes"), treeifyThis(x.params, "params")))
       is SqlQuery<*> -> Tree.Apply("SqlQuery", iteratorOf(treeifyThis(x.xr, "xr"), treeifyThis(x.runtimes, "runtimes"), treeifyThis(x.params, "params")))
       is SqlAction<*, *> -> Tree.Apply("SqlAction", iteratorOf(treeifyThis(x.xr, "xr"), treeifyThis(x.runtimes, "runtimes"), treeifyThis(x.params, "params")))
@@ -178,7 +178,7 @@ class PrintXR<T>(serializer: SerializationStrategy<T>, config: PPrinterConfig = 
 
       // A bunch of FlattenSqlQuery child-elements could be null, don't print them. Also because it has so many different kinds of things in it it really helps to know the headings
       // (There seems to be a bug in pprint where the headings of a null values are not printed when showFieldNames is true. Need to look into that.)
-      is io.exoquery.sql.FlattenSqlQuery ->
+      is io.exoquery.lang.FlattenSqlQuery ->
         when (val treet = super.treeifyComposite(elem, elementName, true)) {
           is Tree.Apply -> {
             val superNodes = treet.body.asSequence()
@@ -188,7 +188,7 @@ class PrintXR<T>(serializer: SerializationStrategy<T>, config: PPrinterConfig = 
           else -> treet
         }
 
-      is io.exoquery.sql.SqlQueryModel -> super.treeifyComposite(elem, elementName, true)
+      is io.exoquery.lang.SqlQueryModel -> super.treeifyComposite(elem, elementName, true)
 
       else -> super.treeifyComposite(elem, elementName, showFieldNames)
     }

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/printing/QueryFileKotlinMakerRoom.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/printing/QueryFileKotlinMakerRoom.kt
@@ -58,7 +58,7 @@ object QueryFileKotlinMakerRoom {
     val type = printable.type
 
     val qqq = """"""".repeat(3)
-    val row = // TODO if it's `val x = capture.select { ... }` then `x` should be the default label
+    val row = // TODO if it's `val x = sql.select { ... }` then `x` should be the default label
       if (query.contains('"')) {
         """|  @Query(${qqq}${query}${qqq})
            |  fun ${label}(${variablesLine}): ${printable.queryOutputType.render()}

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/util/CapturedFunctionScaffold.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/util/CapturedFunctionScaffold.kt
@@ -6,4 +6,4 @@ import io.exoquery.errorCap
 fun <T> scaffoldCapFunctionQuery(query: T, vararg values: Any?): T =
 // The purpose of this function is to carry around the arguments of a compile-time transformed @CapturedFunction instance.
   // It should not be called anywhere in the runtime.
-  errorCap("A @CapturedFunction call cannot be used outside of a capture block")
+  errorCap("A @CapturedFunction call cannot be used outside of a sql block")

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/util/StatementInterpolator.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/util/StatementInterpolator.kt
@@ -1,9 +1,9 @@
 package io.exoquery.util
 
-import io.exoquery.sql.Statement
-import io.exoquery.sql.StringToken
-import io.exoquery.sql.Token
-import io.exoquery.sql.token
+import io.exoquery.lang.Statement
+import io.exoquery.lang.StringToken
+import io.exoquery.lang.Token
+import io.exoquery.lang.token
 import io.exoquery.terpal.Interpolator
 import io.exoquery.terpal.InterpolatorBackend
 import io.exoquery.terpal.InterpolatorFunction

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/EncodingXR.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/EncodingXR.kt
@@ -1,7 +1,7 @@
 package io.exoquery.xr
 
 import io.exoquery.codegen.model.NameProcessorLLM
-import io.exoquery.sql.SqlQueryModel
+import io.exoquery.lang.SqlQueryModel
 import io.exoquery.xr.EncodingXR.protoBuf
 import kotlinx.serialization.decodeFromHexString
 import kotlinx.serialization.encodeToHexString

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/RuntimeQueryBuilder.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/RuntimeQueryBuilder.kt
@@ -11,13 +11,13 @@ import io.exoquery.SqlBatchAction
 import io.exoquery.SqlQuery
 import io.exoquery.TransformXrError
 import io.exoquery.printing.pprintMisc
-import io.exoquery.sql.ParamBatchToken
-import io.exoquery.sql.ParamMultiToken
-import io.exoquery.sql.ParamSingleToken
-import io.exoquery.sql.SqlIdiom
-import io.exoquery.sql.SqlQueryModel
-import io.exoquery.sql.StatelessTokenTransformer
-import io.exoquery.sql.Token
+import io.exoquery.lang.ParamBatchToken
+import io.exoquery.lang.ParamMultiToken
+import io.exoquery.lang.ParamSingleToken
+import io.exoquery.lang.SqlIdiom
+import io.exoquery.lang.SqlQueryModel
+import io.exoquery.lang.StatelessTokenTransformer
+import io.exoquery.lang.Token
 import io.exoquery.util.formatQuery
 
 class RuntimeBuilder(val dialect: SqlIdiom, val pretty: Boolean) {

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/XR.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/XR.kt
@@ -3,9 +3,9 @@ package io.exoquery.xr
 import io.exoquery.BID
 import io.exoquery.pprint.PPrinterConfig
 import io.exoquery.printing.PrintXR
-import io.exoquery.sql.MirrorIdiom
-import io.exoquery.sql.Renderer
-import io.exoquery.sql.Token
+import io.exoquery.lang.MirrorIdiom
+import io.exoquery.lang.Renderer
+import io.exoquery.lang.Token
 import io.exoquery.util.NumbersToWords
 import io.exoquery.util.ShowTree
 import io.exoquery.xr.XR.U.QueryOrExpression
@@ -66,7 +66,7 @@ sealed interface XR {
      * This is used specifically for detecting situations where there is a FlatJoin
      * in both head and tail position. Something like:
      * ```
-     *     capture {
+     *     sql {
      *       people.flatMap { p ->
      *         flatJoin(addresses, p.id = ...).map { a -> p to a }
      *           .flatMap { pa ->

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/XROps.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/XROps.kt
@@ -396,7 +396,7 @@ fun XR.Action.toActionKind(): ActionKind = when (this) {
   is XR.OnConflict -> this.insert.toActionKind()
   is XR.Free ->
     // TODO This is not exactly the best implementaiton. We should probably introduce a FreeKind to the XR
-    //      that we will capture by doing free("...").asInsert/Update/Delete
+    //      that we will sql by doing free("...").asInsert/Update/Delete
     CollectXR.byType<XR.U.CoreAction>(this).firstOrNull()?.let { it.toActionKind() } ?: ActionKind.Unknown
   is XR.TagForSqlAction -> ActionKind.Unknown
 }

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/CompileExtensions.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/CompileExtensions.kt
@@ -554,7 +554,7 @@ fun IrExpression.isSqlAction() =
  * val joe = Person(1, "Joe", "Bloggs", 111)
  * "transaction support" - {
  *   "success" {
- *       capture { insert<Person> { setParams(joe) } }.build<PostgresDialect>()
+ *       sql { insert<Person> { setParams(joe) } }.build<PostgresDialect>()
  *    }
  * }
  * //> Compile Error:
@@ -565,22 +565,22 @@ fun IrExpression.isSqlAction() =
  * "transaction support" - {
  *   "success" {
  *       val joe = Person(1, "Joe", "Bloggs", 111)
- *       capture { insert<Person> { setParams(joe) } }.build<PostgresDialect>()
+ *       sql { insert<Person> { setParams(joe) } }.build<PostgresDialect>()
  *    }
  * }
  * ```
- * It was then noted that the above consturct would trivially work if the capture block was writtein to a new variable
+ * It was then noted that the above consturct would trivially work if the sql block was writtein to a new variable
  * ```
  * "transaction support" - {
  *   "success" {
  *       val joe = Person(1, "Joe", "Bloggs", 111)
- *       val cap = capture { insert<Person> { setParams(joe) } }
+ *       val cap = sql { insert<Person> { setParams(joe) } }
  *       cap.build<PostgresDialect>()
  *    }
  * }
  * ```
  * This leads me to belive that specifically in the situation where the variable is not created,
- * the way the `capture { ... }` is munged around inside of the TransformCompileQuery, the original
+ * the way the `sql { ... }` is munged around inside of the TransformCompileQuery, the original
  * expression becomes somehow invalid. Writing it to a variable seems to introduce some kind of stability
  * that allows it to be resused. As of yet I have not seen similar issues with constructs like `param`
  * but if they do arise, a similar solution (i.e. creating a run-function with a internal-variable

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/settings/ExoCompileOptions.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/settings/ExoCompileOptions.kt
@@ -26,7 +26,7 @@ class ExoCompileOptionsBuilder {
 
   fun build(): ExoCompileOptions {
     return ExoCompileOptions(
-      requireNotNull(entitiesBaseDir) { "A non-null base-directory for generated entities (i.e. from the capture.generate block" },
+      requireNotNull(entitiesBaseDir) { "A non-null base-directory for generated entities (i.e. from the sql.generate block" },
       requireNotNull(generationDir) { "A non-null generationDir must be provided" },
       requireNotNull(projectSrcDir) { "A non-null projectSrcDir must be provided" },
       requireNotNull(sourceSetName) { "A non-null sourceSetName must be provided" },

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/ExprModelContainers.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/ExprModelContainers.kt
@@ -4,8 +4,8 @@ import io.exoquery.*
 import io.exoquery.plugin.trees.Lifter
 import io.exoquery.plugin.trees.PT
 import io.exoquery.plugin.trees.simpleTypeArgs
-import io.exoquery.sql.Token
-import io.exoquery.sql.token
+import io.exoquery.lang.Token
+import io.exoquery.lang.token
 import org.jetbrains.kotlin.ir.builders.irBoolean
 import org.jetbrains.kotlin.ir.builders.irNull
 import org.jetbrains.kotlin.ir.builders.irString

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCapturedExpression.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCapturedExpression.kt
@@ -48,12 +48,12 @@ class TransformCapturedExpression(val superTransformer: VisitTransformExpression
           }
         ) ?: parseError("The expression has an invalid structure", expression)
 
-      // Transform the contents of `capture { ... }` this is important for several reasons,
+      // Transform the contents of `sql { ... }` this is important for several reasons,
       // most notable any kind of variables used inside that need to be inlined e.g:
-      // val x = capture { 123 }
-      // val y = capture { x.use + 1 } // <- this is what we are transforming
+      // val x = sql { 123 }
+      // val y = sql { x.use + 1 } // <- this is what we are transforming
       // Then the `val y` needs to first be transformed into:
-      // val y = capture { SqlExpression(XR.Int(123), ...).use + 1 } which will be done by TransformProjectCapture
+      // val y = sql { SqlExpression(XR.Int(123), ...).use + 1 } which will be done by TransformProjectCapture
       // which is called by the superTransformer.visitBlockBody
       val body = superTransformer.visitBlockBody(bodyRaw) as IrBlockBody
       val (xr, dynamics) = Parser.scoped { Parser.parseFunctionBlockBody(body) }

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCapturedQuery.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCapturedQuery.kt
@@ -58,12 +58,12 @@ class TransformCapturedQuery(val superTransformer: VisitTransformExpressions, va
         )
           ?: parseError("The qeury expression has an invalid structure", expression)
 
-      // Transform the contents of `capture { ... }` this is important for several reasons,
+      // Transform the contents of `sql { ... }` this is important for several reasons,
       // most notable any kind of variables used inside that need to be inlined e.g:
-      // val x = capture { 123 }
-      // val y = capture { x.use + 1 } // <- this is what we are transforming
+      // val x = sql { 123 }
+      // val y = sql { x.use + 1 } // <- this is what we are transforming
       // Then the `val y` needs to first be transformed into:
-      // val y = capture { SqlExpression(XR.Int(123), ...).use + 1 } which will be done by TransformProjectCapture
+      // val y = sql { SqlExpression(XR.Int(123), ...).use + 1 } which will be done by TransformProjectCapture
       // which is called by the superTransformer.visitBlockBody
       val body = superTransformer.recurse(bodyExpr)
       Parser.scoped { Parser.parseQueryFromBlock(body) }

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCompileQuery.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCompileQuery.kt
@@ -12,10 +12,10 @@ import io.exoquery.plugin.trees.SqlActionExpr
 import io.exoquery.plugin.trees.SqlBatchActionExpr
 import io.exoquery.plugin.trees.SqlQueryExpr
 import io.exoquery.plugin.trees.simpleTypeArgs
-import io.exoquery.sql.PostgresDialect
-import io.exoquery.sql.Renderer
-import io.exoquery.sql.SqlIdiom
-import io.exoquery.sql.Token
+import io.exoquery.PostgresDialect
+import io.exoquery.lang.Renderer
+import io.exoquery.lang.SqlIdiom
+import io.exoquery.lang.Token
 import io.exoquery.util.TraceConfig
 import io.exoquery.xr.XR
 import io.exoquery.xr.encode
@@ -98,10 +98,10 @@ class TransformCompileQuery(val superTransformer: VisitTransformExpressions) : T
         val (traceConfig, writeSource) = ComputeEngineTracing.invoke(fileLabel, dialectType)
         val (construct, clsPackageName) = extractDialectConstructor(dialectType)
 
-        // If sqlQueryExprRaw is an Uprootable then we need to do superTransformer.visitCall on that which typically will happen if you call .build on a capture directly
-        // e.g. in `capture { Table<Person>() }.build<PostgresDialect>()` sqlQueryExprRaw will be the IrCall `capture { Table<Person>() }` on which we need to call the superTransformer.visitCall.
+        // If sqlQueryExprRaw is an Uprootable then we need to do superTransformer.visitCall on that which typically will happen if you call .build on a sql directly
+        // e.g. in `sql { Table<Person>() }.build<PostgresDialect>()` sqlQueryExprRaw will be the IrCall `sql { Table<Person>() }` on which we need to call the superTransformer.visitCall.
         // In the case that sqlQueryExprRaw is some kind of expression e.g.
-        // val cap = capture { Table<Person>() }; cap.build<PostgresDialect>() then the uprootable has already been created by the variable declaration
+        // val cap = sql { Table<Person>() }; cap.build<PostgresDialect>() then the uprootable has already been created by the variable declaration
         // and is something like `val cap = SqlQuery(xr=...)`. That means that we need to do a TransformProjectCapture on the `cap` varaible that is being called
         // which is invoked by the `superTransformer.visitExpression`.
         // In both of these cases superTransformer.recurse delegates-out to the correct transformer based on the type-match of the expression.

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformProjectCapture2.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformProjectCapture2.kt
@@ -98,8 +98,8 @@ class TransformProjectCapture2(val superTransformer: VisitTransformExpressions) 
 
         // ================ If we're at the root (i.e. the element is of type OwnerChain.Root) we need to determine what to do based on the type of the root element ================
         // 0. If it's null a previous operation has failed, return null and we're done
-        // 1. If we're a Uprootable then just go up one level, the level above will will handle capture-projection
-        // 2. If we're not an uprootable try doing the superTransform.visitCall on it. If it becomes an uprootable then return it, the level above will handle capture-projection
+        // 1. If we're a Uprootable then just go up one level, the level above will will handle sql-projection
+        // 2. If we're not an uprootable try doing the superTransform.visitCall on it. If it becomes an uprootable then return it, the level above will handle sql-projection
         // Note be sure to NEVER return a null other than from anything but a root since this sequence of operations modifies intermeidate expressions
         // and returning `null` effectively tells the upstream "nothing has happened".
         node is OwnerChain.Root -> {
@@ -148,10 +148,10 @@ class TransformProjectCapture2(val superTransformer: VisitTransformExpressions) 
         // TODO need to create a putUprootableIfCrossFile call in the primary traverser in order to put XRs of functions being compiled
         //      that were never called yet.
 
-        // ================ If we're not a Root that means some previous root up the chain succeeded (either doing #1 or #2 above) do we capture-projection and go up the chain ================
+        // ================ If we're not a Root that means some previous root up the chain succeeded (either doing #1 or #2 above) do we sql-projection and go up the chain ================
         // Instructions: say we've got a case of:
-        // fun foo() = capture { Table<Person>() }
-        // fun bar() = capture { foo().filter { it.name == "Alice" } }
+        // fun foo() = sql { Table<Person>() }
+        // fun bar() = sql { foo().filter { it.name == "Alice" } }
         // `fun foo()` will be the node.origin and will be the uprootableParent when we come back from it
         // `node` will be the `foo()` node.call` IrCall from bar that we need to project into an SqlQuery(..., params=params + foo().params) call
         // That means we need to:

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformScaffoldAnnotatedFunctionCall.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformScaffoldAnnotatedFunctionCall.kt
@@ -119,7 +119,7 @@ class TransformScaffoldAnnotatedFunctionCall(val superTransformer: VisitTransfor
 
     // Need to project the call to make it uprootable in the paresr in later stages.
     // For example
-    // @CapturedFunction fun joes(people: SqlQuery<Person>) = capture { people.filter { p -> p.name == "Joe" } }
+    // @CapturedFunction fun joes(people: SqlQuery<Person>) = sql { people.filter { p -> p.name == "Joe" } }
     // IN the TransformAnnotatedFunction turns into:
     //     fun joes() = SqlQuery(xr = XR.Function(args=[people], body=(people.filter { p -> p.name == "Joe" })))
     //   Or more simply put:
@@ -149,8 +149,8 @@ class TransformScaffoldAnnotatedFunctionCall(val superTransformer: VisitTransfor
     // And the parser will know that `joes` is a pluckable function and create the following:
     //   val drivingJoes = SqlQuery(Apply(Tag(123), listOf(People.filterAge)), runtimes={Tag(123)->joes})
 
-    // Also note that if there is a receiver e.g. @CapturedFunction Person.joinAddress(street: String) = capture { flatJoin(Table<Address>().filter { street == ... }) { ... } }
-    // and the it used as capture { val p = from(people); val a = from(a.joinAddresses("123 someplace"))
+    // Also note that if there is a receiver e.g. @CapturedFunction Person.joinAddress(street: String) = sql { flatJoin(Table<Address>().filter { street == ... }) { ... } }
+    // and the it used as sql { val p = from(people); val a = from(a.joinAddresses("123 someplace"))
     // we need the scaffold to have the receiver-position element i.e. `a` to be the 1st argument
     // p.e. scaffoldCapFunctionQuery((Person, String) -> SqlQuery<Address> i.e. joinAddresses, args=[a, "123 someplace"])
 
@@ -217,7 +217,7 @@ class TransformScaffoldAnnotatedFunctionCall(val superTransformer: VisitTransfor
     // Note that the one case that we haven't considered aboive is where the argument to the function call i.e. People.filterAge
     // itself is a uprootable variable for example:
     //   val drivingPeople = captured { Table<Person>().filter { p -> p.age > 18 } }    // a.k.a. SqlQuery(xr=People.filterAge)
-    //   @CapturedFunction fun joes(people: SqlQuery<Person>) = capture { people.filter { p -> p.name == "Joe" } }
+    //   @CapturedFunction fun joes(people: SqlQuery<Person>) = sql { people.filter { p -> p.name == "Joe" } }
     //   val drivingJoes = captured { joes(drivingPeople) }
     // IN that situation the scaffolding would look like so:
     //   val drivingJoes = scaffoldCapFunctionQuery(SqlQuery((people)=>people.filterJoe <- i.e. `joes`), args=[drivingPeople] <- NOTE Here!)

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/VisitTransformExpressions.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/VisitTransformExpressions.kt
@@ -105,7 +105,7 @@ class VisitTransformExpressions(
   override fun visitFileNew(file: IrFile, data: VisitorContext): IrFile {
     // Not sure if we should transfer any symbols from the previous and where they can be. Genrally transfer of symbols
     // should only be cumulative in a captured context for example something like:
-    // capture {
+    // sql {
     //   people.flatMap { p ->
     //     val foo = "Blah"
     //     addresses.map { a ->
@@ -215,9 +215,9 @@ class VisitTransformExpressions(
 
         transformProjectCapture.matches(expression) ->
           transformProjectCapture.transform(expression) ?: run {
-            // In many situations where the capture cannot be projected e.g.
-            // val x = if(x) capture { 123 } else capture { 456 } we need to go further into the expression
-            // and transform the `capture { ... }` expressions inside into SqlExpession instances. Calling
+            // In many situations where the sql cannot be projected e.g.
+            // val x = if(x) sql { 123 } else sql { 456 } we need to go further into the expression
+            // and transform the `sql { ... }` expressions inside into SqlExpession instances. Calling
             // the super-transformer does that.
             super.visitExpression(expression, data)
           }
@@ -242,7 +242,7 @@ class VisitTransformExpressions(
     val builderContext = CX.Builder(scopeCtx)
 
     val transformPrint = TransformPrintSource(this)
-    // TODO just for Expression capture or also for Query capture? Probably both
+    // TODO just for Expression sql or also for Query sql? Probably both
     val transformCapture = TransformCapturedExpression(this)
     val transformCaptureQuery = TransformCapturedQuery(this, "[ExoQuery: VisitTransformExpressions-VisitCall]")
     val transformSelectClause = TransformSelectClause(this)

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ExprModel.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ExprModel.kt
@@ -88,7 +88,7 @@ data class ParamBind(val bid: BID, val value: IrExpression, val paramSerializer:
       context (CX.Scope, CX.Builder) override fun build(bid: BID, originalValue: IrExpression, lifter: Lifter) =
         with(lifter) {
           // Remember that the transformer (called below) that replaces the batch_varaible mutates the Ir so we need to make
-          // copies of it in case the actual batch-variable is being reused for multiple expression (as it happens when we use capture.batch(people) { p -> ... setParams(p)... })
+          // copies of it in case the actual batch-variable is being reused for multiple expression (as it happens when we use sql.batch(people) { p -> ... setParams(p)... })
           // I.e. since during the eleboration phase, the actual `p` parameter gets copied so once we mutate it, it will be the same underlying instance for all
           // expressions in the elaboration. Therefore when we need to actually replace the underlying symbol we need to copy all of them.
           // If you don't do that you'll get strange `No mapping for symbol: VALUE_PARAMETER name:p` errors. This is especially confusing then the `p` variable
@@ -116,7 +116,7 @@ data class ParamBind(val bid: BID, val value: IrExpression, val paramSerializer:
             isAssignable = batchVariable.isAssignable,
             symbol = newSymbol,
             isNoinline = batchVariable.isNoinline,
-            // batch variable is the `p` in capture.batch(people) { p -> ... } it always a Regular parameter
+            // batch variable is the `p` in sql.batch(people) { p -> ... } it always a Regular parameter
             kind = IrParameterKind.Regular
           )
 
@@ -346,7 +346,7 @@ object SqlExpressionExpr {
 
     // re-create the SqlExpression instance. Note that we need a varaible from which to take params
     // So for example say we have something like:
-    // val x = capture { 123 } // i.e. SqlExpression(unpack(xyz), params=...)
+    // val x = sql { 123 } // i.e. SqlExpression(unpack(xyz), params=...)
     // val y = x
     // we want to change `val y` to:
     // val y = SqlExpression(unpack(xyz), lifts=x.lifts)

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/Lifter.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/Lifter.kt
@@ -12,7 +12,7 @@ import io.exoquery.plugin.stableIdentifier
 import io.exoquery.plugin.transform.CX
 import io.exoquery.plugin.transform.call
 import io.exoquery.plugin.transform.callDispatch
-import io.exoquery.sql.*
+import io.exoquery.lang.*
 import io.exoquery.util.TraceConfig
 import io.exoquery.util.TraceType
 import org.jetbrains.kotlin.ir.builders.*

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParseAction.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParseAction.kt
@@ -33,7 +33,7 @@ object ParseAction {
   // Parse an action, normally dynamic splicing of actions is not allowed, the only exception to this is from a free(... action ...) call where `action` is dynamic (see the ParseFree in ParserOps)
   fun parse(expr: IrExpression, dynamicCallsAllowed: Boolean = false): XR.Action =
     on(expr).match<XR.Action>(
-      // the `insert` part of capture { insert<Person> { set ... } }
+      // the `insert` part of sql { insert<Person> { set ... } }
       case(ParseFree.match()).thenThis { (components), _ ->
         ParseFree.parse(expr, components, funName)
       },

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParserOps.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParserOps.kt
@@ -111,15 +111,15 @@ fun IrDeclarationReference.realOwner(): RealOwner {
       // but normally they will be SqlQuery/SqlExpression instances
       elem is IrFunction && elem.hasAnnotation<CapturedDynamic>() -> RealOwner.CapturedDynamicFunctionVariable(elem, varType)
 
-          // If the owner of the function is a ExoQuery captured-block (i.e. inside of a capture { ... } function of some sort) we immediately
-      // know the parent function was defined inside of the capture and is therefore a "captured variable"
+          // If the owner of the function is a ExoQuery captured-block (i.e. inside of a sql { ... } function of some sort) we immediately
+      // know the parent function was defined inside of the sql and is therefore a "captured variable"
       elem is IrFunction && elem.extensionParam?.type?.isClass<CapturedBlock>() ?: false -> RealOwner.CapturedBlock
       // Otherwise we need to keep recursing up to the owner
       elem is IrFunction -> rec(elem.symbol.owner.parent, varType, recurseCount - 1)
 
       // If it is a value-parameter, check to see if it's parent is a captured-function or captured-dynamic function
       // otherwise it is a parameter of some intermediate function inside (e.g. a function used in a map{} or let{} or something
-      // that is completely inside the capture { ... } block but not actually a parameter of the capture itself)
+      // that is completely inside the sql { ... } block but not actually a parameter of the sql itself)
       elem is IrValueParameter ->
         when (val parent = elem.symbol.owner.parent) {
           is IrFunction if parent.hasAnnotation<CapturedFunction>() ->

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/TypeParser.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/TypeParser.kt
@@ -91,7 +91,7 @@ object TypeParser {
       // Need to check this before checking the isDataClass clause because for things like custom types e.g. data class MyCustomDate(year: Int, month: Int, day: Int)
       // it could be a data-class but still needs to be interpreted as a value (usually this will be because the type itself is annotated with @Contextual or @ExoValue
       // when it is coming out of a param(...)/paramCtx(...) call or it is a dereferenced property of a data-class that has @Contextual or @ExoValue marked on the type
-      // of the member itself e.g. `data class Person(bornOn: @Contextual LocalDate)`, `capture { Table<Person>().map { p -> p.bornOn <- type: @Contextual MyCustomDate } }`.
+      // of the member itself e.g. `data class Person(bornOn: @Contextual LocalDate)`, `sql { Table<Person>().map { p -> p.bornOn <- type: @Contextual MyCustomDate } }`.
       case(Ir.Type.Value[Is()]).then { type ->
         //error("----------- Got here: ${type} ----------")
         if (type.isBoolean())

--- a/exoquery-runner-android/src/androidMain/kotlin/io/exoquery/android/MessagesAndroid.kt
+++ b/exoquery-runner-android/src/androidMain/kotlin/io/exoquery/android/MessagesAndroid.kt
@@ -7,10 +7,10 @@ val SqliteNativeCantReturningKeysIfNotInsert =
 In Sqlite for Android returningKeys can only be used for inserts. If you want to return a value from a query use the `returning` method to define a proper SQL RETURNING Clause.
 
 For example, instead of this:
-val query = capture { update<Person> { set(firstName to "Joe") } }.where { lastName == "Bloggs" }.returningKeys { id }
+val query = sql { update<Person> { set(firstName to "Joe") } }.where { lastName == "Bloggs" }.returningKeys { id }
 
 You can do this:
-val query = capture { update<Person> { set(firstName to "Joe") } }.where { lastName == "Bloggs" }.returning { id }
+val query = sql { update<Person> { set(firstName to "Joe") } }.where { lastName == "Bloggs" }.returning { id }
 
 This will become:
 UPDATE Person SET firstName = ? WHERE lastName = ? RETURNING id

--- a/exoquery-runner-android/src/androidMain/kotlin/io/exoquery/android/MyRoomDao.kt
+++ b/exoquery-runner-android/src/androidMain/kotlin/io/exoquery/android/MyRoomDao.kt
@@ -4,13 +4,13 @@ package io.exoquery.android
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import io.exoquery.annotation.ExoRoomInterface
-import io.exoquery.capture
+import io.exoquery.sql
 
 @Entity(tableName = "Person")
 data class PersonRoom(@PrimaryKey(autoGenerate = true) val id: Int = 0, val firstName: String, val lastName: String, val age: Int)
 
 val joes =
-  capture.select {
+  sql.select {
     val p = from(Table<PersonRoom>())
     where { p.firstName == paramRoom<String>("myFirstName") }
     p

--- a/exoquery-runner-android/src/androidUnitTest/kotlin/io/exoquery/android/ActionSpec.kt
+++ b/exoquery-runner-android/src/androidUnitTest/kotlin/io/exoquery/android/ActionSpec.kt
@@ -2,7 +2,7 @@ package io.exoquery.android
 
 import io.exoquery.testdata.Person
 import io.exoquery.SqliteDialect
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.android.AndroidDatabaseController
 import io.exoquery.controller.runActions
 import kotlinx.coroutines.runBlocking
@@ -28,7 +28,7 @@ class ActionSpec {
 
   @Test
   fun `insert simple`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -37,7 +37,7 @@ class ActionSpec {
 
   @Test
   fun `insert simple with params`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { set(firstName to param("Joe"), lastName to param("Bloggs"), age to param(111)) }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -46,7 +46,7 @@ class ActionSpec {
 
   @Test
   fun `insert simple with setParams`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { setParams(Person(1, "Joe", "Bloggs", 111)) }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -55,7 +55,7 @@ class ActionSpec {
 
   @Test
   fun `insert simple with setParams and exclusion`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { setParams(Person(1, "Joe", "Bloggs", 111)).excluding(id) }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -64,7 +64,7 @@ class ActionSpec {
 
   @Test
   fun `insert with returning keys`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returningKeys { id }
     }
     val build = q.build<SqliteDialect>()
@@ -79,7 +79,7 @@ class ActionSpec {
   @Test
   fun `update simple`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -89,7 +89,7 @@ class ActionSpec {
   @Test
   fun `update no condition`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       update<Person> { set(firstName to param("Joe"), lastName to param("Bloggs"), age to 111) }.all()
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 2
@@ -102,7 +102,7 @@ class ActionSpec {
   @Test
   fun `delete simple`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       delete<Person>().filter { p -> p.id == 1 }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -112,7 +112,7 @@ class ActionSpec {
   @Test
   fun `delete no condition`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       delete<Person>().all()
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 2
@@ -131,7 +131,7 @@ class ActionSpec {
   // Robolectric uses sqlite4java which is stuck an the ancient sqlite 3.8.7 version which doesn't support RETURNING.
   //@Test
   //fun `insert with returning`() = runBlocking {
-  //  val q = capture {
+  //  val q = sql {
   //    insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id + 100 }
   //  }
   //  val build = q.build<SqliteDialect>()
@@ -141,7 +141,7 @@ class ActionSpec {
   //@Test
   //fun `insert with returning using param`() = runBlocking {
   //  val n = 1000
-  //  val q = capture {
+  //  val q = sql {
   //    insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id + 100 + param(n) }
   //  }
   //  val build = q.build<SqliteDialect>()
@@ -150,7 +150,7 @@ class ActionSpec {
   //}
   //@Test
   //fun `insert with returning - multiple`() = runBlocking {
-  //  val q = capture {
+  //  val q = sql {
   //    insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id to p.firstName }
   //  }
   //  val build = q.build<SqliteDialect>()
@@ -160,7 +160,7 @@ class ActionSpec {
   //@Test
   //fun `delete returning`() = runBlocking {
   //  ctx.insertGeorgeAndJim()
-  //  val q = capture {
+  //  val q = sql {
   //    delete<Person>().filter { p -> p.id == 1 }.returning { p -> p.firstName }
   //  }
   //  q.build<SqliteDialect>().runOn(ctx) shouldBe "George"

--- a/exoquery-runner-android/src/androidUnitTest/kotlin/io/exoquery/android/GetSupportSqliteQuery.kt
+++ b/exoquery-runner-android/src/androidUnitTest/kotlin/io/exoquery/android/GetSupportSqliteQuery.kt
@@ -4,8 +4,7 @@ import androidx.sqlite.db.SimpleSQLiteQuery
 import androidx.sqlite.db.SupportSQLiteQuery
 import androidx.test.core.app.ApplicationProvider
 import io.exoquery.SqlCompiledQuery
-import io.exoquery.android.TestDatabase.databaseName
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.android.AndroidDatabaseController
 import io.exoquery.controller.android.AndroidxArrayWrapper
 import io.exoquery.controller.sqlite.Unused
@@ -37,7 +36,7 @@ data class Person(val id: Int, val name: String, val age: Int)
     val ctx = AndroidDatabaseController.fromApplicationContext("empty_database.db", ApplicationProvider.getApplicationContext(), BasicSchemaTerpal)
 
     fun executeQuery(q: SupportSQLiteQuery): SupportSQLiteQuery {
-      val query = capture.select {
+      val query = sql.select {
         val p = from(Table<Person>())
         p
       }

--- a/exoquery-runner-android/src/androidUnitTest/kotlin/io/exoquery/android/QuerySpec.kt
+++ b/exoquery-runner-android/src/androidUnitTest/kotlin/io/exoquery/android/QuerySpec.kt
@@ -5,7 +5,7 @@ import io.exoquery.Ord
 import io.exoquery.testdata.Person
 import io.exoquery.SqliteDialect
 import io.exoquery.testdata.Robot
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.printing.pprintMisc
 import junit.framework.TestCase.assertEquals
@@ -51,7 +51,7 @@ class QuerySpec {
 
   @Test
   fun `simple`() = runBlocking {
-    val q = capture { Table<Person>() }
+    val q = sql { Table<Person>() }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222),
@@ -61,7 +61,7 @@ class QuerySpec {
 
   @Test
   fun `filter`() = runBlocking {
-    val q = capture { Table<Person>().filter { it.firstName == "Joe" } }
+    val q = sql { Table<Person>().filter { it.firstName == "Joe" } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -71,7 +71,7 @@ class QuerySpec {
   @Test
   fun `filter with param`() = runBlocking {
     val joe = "Joe"
-    val q = capture { Table<Person>().filter { it.firstName == param(joe) } }
+    val q = sql { Table<Person>().filter { it.firstName == param(joe) } }
     val built = q.build<SqliteDialect>()
 
     println(pprintMisc(built))
@@ -84,7 +84,7 @@ class QuerySpec {
 
   @Test
   fun `where`() = runBlocking {
-    val q = capture { Table<Person>().where { firstName == "Joe" } }
+    val q = sql { Table<Person>().where { firstName == "Joe" } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -93,7 +93,7 @@ class QuerySpec {
 
   @Test
   fun `filter + sortedBy`() = runBlocking {
-    val q = capture { Table<Person>().filter { it.firstName == "Joe" }.sortedBy { it.age } }
+    val q = sql { Table<Person>().filter { it.firstName == "Joe" }.sortedBy { it.age } }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -102,7 +102,7 @@ class QuerySpec {
 
   @Test
   fun `filter + correlated isNotEmpty`() = runBlocking {
-    val q = capture { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isNotEmpty() } }
+    val q = sql { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isNotEmpty() } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -111,7 +111,7 @@ class QuerySpec {
 
   @Test
   fun `filter + correlated isEmpty`() = runBlocking {
-    val q = capture { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isEmpty() } }
+    val q = sql { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isEmpty() } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(3, "Jim", "Roogs", 333)
     )
@@ -119,7 +119,7 @@ class QuerySpec {
 
   @Test
   fun `sort + take`() = runBlocking {
-    val q = capture { Table<Person>().sortedBy { it.age }.take(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.take(1) }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(1, "Joe", "Bloggs", 111)
     )
@@ -127,7 +127,7 @@ class QuerySpec {
 
   @Test
   fun `sort + drop`() = runBlocking {
-    val q = capture { Table<Person>().sortedBy { it.age }.drop(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.drop(1) }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(2, "Joe", "Doggs", 222),
       Person(3, "Jim", "Roogs", 333)
@@ -136,7 +136,7 @@ class QuerySpec {
 
   @Test
   fun `distinct`() = runBlocking {
-    val q = capture { Table<Person>().map { it.firstName }.distinct() }
+    val q = sql { Table<Person>().map { it.firstName }.distinct() }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       "Joe",
       "Jim"
@@ -145,7 +145,7 @@ class QuerySpec {
 
   @Test
   fun `sort + drop + take`() = runBlocking {
-    val q = capture { Table<Person>().sortedBy { it.age }.drop(1).take(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.drop(1).take(1) }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(2, "Joe", "Doggs", 222)
     )
@@ -153,7 +153,7 @@ class QuerySpec {
 
   @Test
   fun `map`() = runBlocking {
-    val q = capture { Table<Person>().map { it.firstName to it.lastName } }
+    val q = sql { Table<Person>().map { it.firstName to it.lastName } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       "Joe" to "Bloggs",
       "Joe" to "Doggs",
@@ -169,7 +169,7 @@ class QuerySpec {
 
   @Test
   fun `map to custom`() = runBlocking {
-    val q = capture { Table<Person>().map { CustomPerson(Name(it.firstName, it.lastName), it.age) } }
+    val q = sql { Table<Person>().map { CustomPerson(Name(it.firstName, it.lastName), it.age) } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       CustomPerson(Name("Joe", "Bloggs"), 111),
       CustomPerson(Name("Joe", "Doggs"), 222),
@@ -179,7 +179,7 @@ class QuerySpec {
 
   @Test
   fun `nested`() = runBlocking {
-    val q = capture { Table<Person>().nested() }
+    val q = sql { Table<Person>().nested() }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222),
@@ -189,9 +189,9 @@ class QuerySpec {
 
   @Test
   fun `union`() = runBlocking {
-    val bloggs = capture { Table<Person>().filter { it.lastName == "Bloggs" } }
-    val doggs = capture { Table<Person>().filter { it.lastName == "Doggs" } }
-    val q = capture { bloggs union doggs }
+    val bloggs = sql { Table<Person>().filter { it.lastName == "Bloggs" } }
+    val doggs = sql { Table<Person>().filter { it.lastName == "Doggs" } }
+    val q = sql { bloggs union doggs }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -200,11 +200,11 @@ class QuerySpec {
 
   @Test
   fun `deconstruct columns - from a table`() = runBlocking {
-    val names = capture.select {
+    val names = sql.select {
       val p = from(Table<Person>())
       p.firstName to p.lastName
     }
-    val q = capture.select {
+    val q = sql.select {
       val (first, last) = from(names)
       first + " - " + last
     }
@@ -217,11 +217,11 @@ class QuerySpec {
 
   @Test
   fun `deconstruct - columns - from a table - mapped`() = runBlocking {
-    val names = capture.select {
+    val names = sql.select {
       val p = from(Table<Person>())
       p.firstName to p.lastName
     }
-    val q = capture {
+    val q = sql {
       names.map { (first, last) -> first + " - " + last }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
@@ -234,13 +234,13 @@ class QuerySpec {
   @Test
   fun `deconstruct - join - from a join`() = runBlocking {
     val join =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>())
         val a = join(Table<Address>()) { a -> a.ownerId == p.id }
         p to a
       }
     val deconstuct =
-      capture.select {
+      sql.select {
         val (p, a) = from(join)
         val r = join(Table<Robot>()) { r -> r.ownerId == p.id }
         Triple(p, a, r)
@@ -257,7 +257,7 @@ class QuerySpec {
 
   @Test
   fun `deconstruct - Person, Address - join`() = runBlocking {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       val a = join(Table<Address>()) { a -> a.ownerId == p.id }
       p to a
@@ -271,7 +271,7 @@ class QuerySpec {
 
   @Test
   fun `deconstruct - Person, Address - left join`() = runBlocking {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
       p to a
@@ -286,7 +286,7 @@ class QuerySpec {
 
   @Test
   fun `deconstruct - Person, Address - left-join + groupBy(name)`() = runBlocking {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
       groupBy(p.firstName)
@@ -300,7 +300,7 @@ class QuerySpec {
 
   @Test
   fun `deconstruct - Person, Address - left-join + groupBy(name) + filter`() = runBlocking {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
       where { p.lastName == "Doggs" || p.lastName == "Roogs" }
@@ -315,7 +315,7 @@ class QuerySpec {
 
   @Test
   fun `deconstruct - Person, address - left-join + groupBy(name) + filter + orderBy`() = runBlocking {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
       where { p.lastName == "Doggs" || p.lastName == "Roogs" }

--- a/exoquery-runner-android/src/androidUnitTest/kotlin/io/exoquery/android/TestData.kt
+++ b/exoquery-runner-android/src/androidUnitTest/kotlin/io/exoquery/android/TestData.kt
@@ -2,21 +2,20 @@ package io.exoquery.android
 
 import io.exoquery.testdata.Person
 import io.exoquery.SqliteDialect
-import io.exoquery.capture
-import io.exoquery.capture.invoke
+import io.exoquery.sql
 import io.exoquery.controller.android.AndroidDatabaseController
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
-suspend fun AndroidDatabaseController.people() = capture { Table<Person>() }.build<PostgresDialect>().runOn(this)
+suspend fun AndroidDatabaseController.people() = sql { Table<Person>() }.build<PostgresDialect>().runOn(this)
 
 suspend fun AndroidDatabaseController.insertPerson(person: Person) =
-  capture { insert<Person> { setParams(person) } }.build<SqliteDialect>().runOn(this)
+  sql { insert<Person> { setParams(person) } }.build<SqliteDialect>().runOn(this)
 
 suspend fun AndroidDatabaseController.insertPeople() =
-  people.forEach { capture { insert<Person> { setParams(it) } }.build<SqliteDialect>().runOn(this) }
+  people.forEach { sql { insert<Person> { setParams(it) } }.build<SqliteDialect>().runOn(this) }
 
 suspend fun AndroidDatabaseController.insertAllPeople() =
-  allPeople.forEach { capture { insert<Person> { setParams(it) } }.build<SqliteDialect>().runOn(this) }
+  allPeople.forEach { sql { insert<Person> { setParams(it) } }.build<SqliteDialect>().runOn(this) }
 
 val joe = Person(1, "Joe", "Bloggs", 111)
 val joe2 = Person(2, "Joe", "Doggs", 222)

--- a/exoquery-runner-android/src/androidUnitTest/kotlin/io/exoquery/android/TransactionSpec.kt
+++ b/exoquery-runner-android/src/androidUnitTest/kotlin/io/exoquery/android/TransactionSpec.kt
@@ -1,10 +1,10 @@
 package io.exoquery.android
 
 import io.exoquery.testdata.Person
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.controller.transaction
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.runner.RunWith
@@ -30,12 +30,12 @@ class TransactionSpec {
   private val jack = Person(2, "Jack", "Roogs", 222)
 
   private suspend fun select() =
-    capture { Table<Person>() }.build<PostgresDialect>().runOn(ctx)
+    sql { Table<Person>() }.build<PostgresDialect>().runOn(ctx)
 
   @Test
   fun `transaction success`() = runBlocking {
     ctx.transaction {
-      capture {
+      sql {
         insert<Person> { setParams(joe) }
       }.build<PostgresDialect>().runOnTransaction()
     }
@@ -45,11 +45,11 @@ class TransactionSpec {
   @Test
   fun `transaction failure`() = runBlocking {
     // Insert joe record
-    capture { insert<Person> { setParams(joe) } }.build<PostgresDialect>().runOn(ctx)
+    sql { insert<Person> { setParams(joe) } }.build<PostgresDialect>().runOn(ctx)
 
     kotlin.test.assertFailsWith<IllegalStateException> {
       ctx.transaction {
-        capture {
+        sql {
           insert<Person> { setParams(jack) }
         }.build<PostgresDialect>().runOnTransaction()
         throw IllegalStateException()
@@ -60,7 +60,7 @@ class TransactionSpec {
 
   @Test
   fun `nested transaction`() = runBlocking {
-    val cap = capture {
+    val cap = sql {
       insert<Person> { setParams(joe) }
     }.build<PostgresDialect>()
 

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/TestData.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/TestData.kt
@@ -1,29 +1,29 @@
 package io.exoquery
 
 import io.exoquery.testdata.Person
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.controller.jdbc.JdbcController
 import io.exoquery.jdbc.runOn
 import io.exoquery.testdata.PersonNullable
 import io.exoquery.testdata.PersonWithId
 import io.exoquery.testdata.PersonWithIdCtx
 
-suspend fun JdbcController.people() = capture { Table<Person>() }.build<PostgresDialect>().runOn(this)
+suspend fun JdbcController.people() = sql { Table<Person>() }.build<PostgresDialect>().runOn(this)
 
-suspend fun JdbcController.peopleNullable() = capture { Table<PersonNullable>() }.build<PostgresDialect>().runOn(this)
+suspend fun JdbcController.peopleNullable() = sql { Table<PersonNullable>() }.build<PostgresDialect>().runOn(this)
 
-suspend fun JdbcController.peopleWithIdCtx() = capture { Table<PersonWithIdCtx>() }.build<PostgresDialect>().runOn(this)
+suspend fun JdbcController.peopleWithIdCtx() = sql { Table<PersonWithIdCtx>() }.build<PostgresDialect>().runOn(this)
 
-suspend fun JdbcController.peopleWithId() = capture { Table<PersonWithId>() }.build<PostgresDialect>().runOn(this)
+suspend fun JdbcController.peopleWithId() = sql { Table<PersonWithId>() }.build<PostgresDialect>().runOn(this)
 
 suspend fun JdbcController.insertPerson(person: Person) =
-  capture { insert<Person> { setParams(person).excluding(id) } }.build<PostgresDialect>().runOn(this)
+  sql { insert<Person> { setParams(person).excluding(id) } }.build<PostgresDialect>().runOn(this)
 
 suspend fun JdbcController.insertPeople() =
-  people.forEach { capture { insert<Person> { setParams(it) } }.build<PostgresDialect>().runOn(this) }
+  people.forEach { sql { insert<Person> { setParams(it) } }.build<PostgresDialect>().runOn(this) }
 
 suspend fun JdbcController.insertAllPeople() =
-  allPeople.forEach { capture { insert<Person> { setParams(it) } }.build<PostgresDialect>().runOn(this) }
+  allPeople.forEach { sql { insert<Person> { setParams(it) } }.build<PostgresDialect>().runOn(this) }
 
 val joe = Person(1, "Joe", "Bloggs", 111)
 val joe2 = Person(2, "Joe", "Doggs", 222)

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/examples/Example.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/examples/Example.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.runBlocking
 fun main() {
   val emb = EmbeddedPostgres.start()
   val ds = emb.postgresDatabase
-  val query = capture {
+  val query = sql {
     Table<Person>().filter { p -> p.lastName == "Ioffe" }
   }
 

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/h2/ActionSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/h2/ActionSpec.kt
@@ -3,13 +3,13 @@ package io.exoquery.h2
 import io.exoquery.testdata.Person
 import io.exoquery.H2Dialect
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.jdbc.JdbcController
 import io.exoquery.controller.runActions
 import io.exoquery.joe
 import io.exoquery.people
 import io.exoquery.jdbc.runOn
-import io.exoquery.sql.SqlServerDialect
+import io.exoquery.SqlServerDialect
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -30,28 +30,28 @@ class ActionSpec : FreeSpec({
 
   "insert" - {
     "simple" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }
       }
       q.build<H2Dialect>().runOn(ctx) shouldBe 1
       ctx.people() shouldBe listOf(joe)
     }
     "simple with params" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to param("Joe"), lastName to param("Bloggs"), age to param(111)) }
       }
       q.build<H2Dialect>().runOn(ctx) shouldBe 1
       ctx.people() shouldBe listOf(joe)
     }
     "simple with setParams" {
-      val q = capture {
+      val q = sql {
         insert<Person> { setParams(Person(1, "Joe", "Bloggs", 111)) }
       }
       q.build<H2Dialect>().runOn(ctx) shouldBe 1
       ctx.people() shouldBe listOf(joe)
     }
     "simple with setParams and exclusion" {
-      val q = capture {
+      val q = sql {
         insert<Person> { setParams(Person(1, "Joe", "Bloggs", 111)).excluding(id) }
       }
       q.build<H2Dialect>().runOn(ctx) shouldBe 1
@@ -59,7 +59,7 @@ class ActionSpec : FreeSpec({
     }
     // 'RETURNING' clauses in SQL are not supported in H2
     //"with returning" {
-    //  val q = capture {
+    //  val q = sql {
     //    insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id + 100 }
     //  }
     //  val build = q.build<H2Dialect>()
@@ -68,7 +68,7 @@ class ActionSpec : FreeSpec({
     //}
     //"with returning using param" {
     //  val n = 1000
-    //  val q = capture {
+    //  val q = sql {
     //    insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id + 100 + param(n) }
     //  }
     //  val build = q.build<H2Dialect>()
@@ -76,7 +76,7 @@ class ActionSpec : FreeSpec({
     //  ctx.people() shouldBe listOf(joe)
     //}
     //"with returning - multiple" {
-    //  val q = capture {
+    //  val q = sql {
     //    insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id to p.firstName }
     //  }
     //  val build = q.build<H2Dialect>()
@@ -84,7 +84,7 @@ class ActionSpec : FreeSpec({
     //  ctx.people() shouldBe listOf(joe)
     //}
     "with returning keys" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returningKeys { id }
       }
       val build = q.build<H2Dialect>()
@@ -92,7 +92,7 @@ class ActionSpec : FreeSpec({
       ctx.people() shouldBe listOf(joe)
     }
     "with returning keys - multiple" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returningKeys { id to firstName }
       }
       val build = q.build<SqlServerDialect>()
@@ -116,7 +116,7 @@ class ActionSpec : FreeSpec({
   "update" - {
     "simple" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }
       }
       q.build<H2Dialect>().runOn(ctx) shouldBe 1
@@ -124,7 +124,7 @@ class ActionSpec : FreeSpec({
     }
     "no condition" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         update<Person> { set(firstName to param("Joe"), lastName to param("Bloggs"), age to 111) }.all()
       }
       q.build<H2Dialect>().runOn(ctx) shouldBe 2
@@ -136,7 +136,7 @@ class ActionSpec : FreeSpec({
     "with setParams" {
       ctx.insertGeorgeAndJim()
       val updateCall = Person(1, "Joe", "Bloggs", 111)
-      val q = capture {
+      val q = sql {
         // TODO need to make a warning when this situation happens, can't have param instances here
         // update<Person> { setParams(Person(1, param("Joe"), param("Bloggs"), 111)) }.filter { p -> p.id == 1 }
         update<Person> { setParams(updateCall) }.filter { p -> p.id == 1 }
@@ -148,7 +148,7 @@ class ActionSpec : FreeSpec({
       ctx.insertGeorgeAndJim()
       // Set a large Id that should specifically be excluded from insertion
       val updateCall = Person(1000, "Joe", "Bloggs", 111)
-      val q = capture {
+      val q = sql {
         // Set the ID to 0 so we can be sure
         update<Person> { setParams(updateCall).excluding(id) }.filter { p -> p.id == 1 }
       }
@@ -158,7 +158,7 @@ class ActionSpec : FreeSpec({
     // Not supported in H2
     //"with returning" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returning { p -> p.id + 100 }
     //  }
     //  val build = q.build<H2Dialect>()
@@ -168,7 +168,7 @@ class ActionSpec : FreeSpec({
     // Not supported in H2
     //"with returning - multiple" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returning { p -> p.id to p.firstName }
     //  }
     //  val build = q.build<H2Dialect>()
@@ -177,7 +177,7 @@ class ActionSpec : FreeSpec({
     //}
     "with returningKeys" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returningKeys { id }
       }
       val build = q.build<H2Dialect>()
@@ -185,7 +185,7 @@ class ActionSpec : FreeSpec({
       ctx.people() shouldContainExactlyInAnyOrder listOf(joe, jim)
     }
     "with returning keys - multiple" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returningKeys { id to firstName }
       }
       val build = q.build<SqlServerDialect>()
@@ -197,7 +197,7 @@ class ActionSpec : FreeSpec({
   "delete" - {
     "simple" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         delete<Person>().filter { p -> p.id == 1 }
       }
       q.build<H2Dialect>().runOn(ctx) shouldBe 1
@@ -205,7 +205,7 @@ class ActionSpec : FreeSpec({
     }
     "no condition" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         delete<Person>().all()
       }
       q.build<H2Dialect>().runOn(ctx) shouldBe 2
@@ -214,7 +214,7 @@ class ActionSpec : FreeSpec({
     // Not supported in H2
     //"with returning" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    delete<Person>().filter { p -> p.id == 1 }.returning { p -> p.id + 100 }
     //  }
     //  val build = q.build<H2Dialect>()
@@ -224,7 +224,7 @@ class ActionSpec : FreeSpec({
     // H2 does not support this
     //"with returningKeys" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    delete<Person>().filter { p -> p.id == 1 }.returningKeys { id }
     //  }
     //  val build = q.build<H2Dialect>()

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/h2/CastingSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/h2/CastingSpec.kt
@@ -1,8 +1,7 @@
 package io.exoquery.h2
 
-import io.exoquery.SqlQuery
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.runOn
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
@@ -11,32 +10,32 @@ class CastingSpec : FreeSpec({
   val ctx = TestDatabases.h2
 
   "Int to String" {
-    val q = capture.select { 1.toString() }
+    val q = sql.select { 1.toString() }
     q.buildFor.H2().runOn(ctx).first() shouldBe "1"
   }
 
   "String to Long" {
-    val q = capture.select { "1".toLong() }
+    val q = sql.select { "1".toLong() }
     q.buildFor.H2().runOn(ctx).first() shouldBe 1
   }
   "String to Int" {
-    val q = capture.select { "1".toInt() }
+    val q = sql.select { "1".toInt() }
     q.buildFor.H2().runOn(ctx).first() shouldBe 1
   }
   "String to Short" {
-    val q = capture.select { "1".toShort() }
+    val q = sql.select { "1".toShort() }
     q.buildFor.H2().runOn(ctx).first() shouldBe 1
   }
   "String to Double" {
-    val q = capture.select { "1.2".toDouble() }
+    val q = sql.select { "1.2".toDouble() }
     q.buildFor.H2().runOn(ctx).first() shouldBe (1.2).toDouble()
   }
   "String to Float" {
-    val q = capture.select { "1.2".toFloat() }
+    val q = sql.select { "1.2".toFloat() }
     q.buildFor.H2().runOn(ctx).first() shouldBe (1.2).toFloat()
   }
   "String to Boolean" {
-    val q = capture.select { "true".toBoolean() }
+    val q = sql.select { "true".toBoolean() }
     q.buildFor.H2().runOn(ctx).first() shouldBe true
   }
 })

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/h2/QuerySpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/h2/QuerySpec.kt
@@ -6,7 +6,7 @@ import io.exoquery.testdata.Person
 import io.exoquery.H2Dialect
 import io.exoquery.testdata.Robot
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.jdbc.runOn
 import io.kotest.core.spec.style.FreeSpec
@@ -38,7 +38,7 @@ class QuerySpec : FreeSpec({
   }
 
   "simple" {
-    val q = capture { Table<Person>() }
+    val q = sql { Table<Person>() }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222),
@@ -47,7 +47,7 @@ class QuerySpec : FreeSpec({
   }
 
   "filter" {
-    val q = capture { Table<Person>().filter { it.firstName == "Joe" } }
+    val q = sql { Table<Person>().filter { it.firstName == "Joe" } }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -56,7 +56,7 @@ class QuerySpec : FreeSpec({
 
   "filter with param" {
     val joe = "Joe"
-    val q = capture { Table<Person>().filter { it.firstName == param(joe) } }
+    val q = sql { Table<Person>().filter { it.firstName == param(joe) } }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -64,7 +64,7 @@ class QuerySpec : FreeSpec({
   }
 
   "where" {
-    val q = capture { Table<Person>().where { firstName == "Joe" } }
+    val q = sql { Table<Person>().where { firstName == "Joe" } }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -72,7 +72,7 @@ class QuerySpec : FreeSpec({
   }
 
   "filter + sortedBy" {
-    val q = capture { Table<Person>().filter { it.firstName == "Joe" }.sortedBy { it.age } }
+    val q = sql { Table<Person>().filter { it.firstName == "Joe" }.sortedBy { it.age } }
     q.build<H2Dialect>().runOn(ctx) shouldBe listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -80,7 +80,7 @@ class QuerySpec : FreeSpec({
   }
 
   "filter + correlated isNotEmpty" {
-    val q = capture { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isNotEmpty() } }
+    val q = sql { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isNotEmpty() } }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -88,21 +88,21 @@ class QuerySpec : FreeSpec({
   }
 
   "filter + correlated isEmpty" {
-    val q = capture { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isEmpty() } }
+    val q = sql { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isEmpty() } }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(3, "Jim", "Roogs", 333)
     )
   }
 
   "sort + take" {
-    val q = capture { Table<Person>().sortedBy { it.age }.take(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.take(1) }
     q.build<H2Dialect>().runOn(ctx) shouldBe listOf(
       Person(1, "Joe", "Bloggs", 111)
     )
   }
 
   "sort + drop" {
-    val q = capture { Table<Person>().sortedBy { it.age }.drop(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.drop(1) }
     q.build<H2Dialect>().runOn(ctx) shouldBe listOf(
       Person(2, "Joe", "Doggs", 222),
       Person(3, "Jim", "Roogs", 333)
@@ -110,7 +110,7 @@ class QuerySpec : FreeSpec({
   }
 
   "distinct" {
-    val q = capture { Table<Person>().map { it.firstName }.distinct() }
+    val q = sql { Table<Person>().map { it.firstName }.distinct() }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       "Joe",
       "Jim"
@@ -118,7 +118,7 @@ class QuerySpec : FreeSpec({
   }
 
   "distinctOn" {
-    val q = capture { Table<Person>().distinctOn { it.firstName } }
+    val q = sql { Table<Person>().distinctOn { it.firstName } }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(3, "Jim", "Roogs", 333)
@@ -126,14 +126,14 @@ class QuerySpec : FreeSpec({
   }
 
   "sort + drop + take" {
-    val q = capture { Table<Person>().sortedBy { it.age }.drop(1).take(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.drop(1).take(1) }
     q.build<H2Dialect>().runOn(ctx) shouldBe listOf(
       Person(2, "Joe", "Doggs", 222)
     )
   }
 
   "map" {
-    val q = capture { Table<Person>().map { it.firstName to it.lastName } }
+    val q = sql { Table<Person>().map { it.firstName to it.lastName } }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       "Joe" to "Bloggs",
       "Joe" to "Doggs",
@@ -148,7 +148,7 @@ class QuerySpec : FreeSpec({
   data class CustomPerson(val name: Name, val age: Int)
 
   "map to custom" {
-    val q = capture { Table<Person>().map { CustomPerson(Name(it.firstName, it.lastName), it.age) } }
+    val q = sql { Table<Person>().map { CustomPerson(Name(it.firstName, it.lastName), it.age) } }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       CustomPerson(Name("Joe", "Bloggs"), 111),
       CustomPerson(Name("Joe", "Doggs"), 222),
@@ -157,7 +157,7 @@ class QuerySpec : FreeSpec({
   }
 
   "nested" {
-    val q = capture { Table<Person>().nested() }
+    val q = sql { Table<Person>().nested() }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222),
@@ -166,9 +166,9 @@ class QuerySpec : FreeSpec({
   }
 
   "union" {
-    val bloggs = capture { Table<Person>().filter { it.lastName == "Bloggs" } }
-    val doggs = capture { Table<Person>().filter { it.lastName == "Doggs" } }
-    val q = capture { bloggs union doggs }
+    val bloggs = sql { Table<Person>().filter { it.lastName == "Bloggs" } }
+    val doggs = sql { Table<Person>().filter { it.lastName == "Doggs" } }
+    val q = sql { bloggs union doggs }
     q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -177,11 +177,11 @@ class QuerySpec : FreeSpec({
 
   "deconstruct" - {
     "columns - from a table" {
-      val names = capture.select {
+      val names = sql.select {
         val p = from(Table<Person>())
         p.firstName to p.lastName
       }
-      val q = capture.select {
+      val q = sql.select {
         val (first, last) = from(names)
         first + " - " + last
       }
@@ -193,11 +193,11 @@ class QuerySpec : FreeSpec({
     }
 
     "columns - from a table - mapped" {
-      val names = capture.select {
+      val names = sql.select {
         val p = from(Table<Person>())
         p.firstName to p.lastName
       }
-      val q = capture {
+      val q = sql {
         names.map { (first, last) -> first + " - " + last }
       }
       q.build<H2Dialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
@@ -209,13 +209,13 @@ class QuerySpec : FreeSpec({
 
     "join - from a join" {
       val join =
-        capture.select {
+        sql.select {
           val p = from(Table<Person>())
           val a = join(Table<Address>()) { a -> a.ownerId == p.id }
           p to a
         }
       val deconstuct =
-        capture.select {
+        sql.select {
           val (p, a) = from(join)
           val r = join(Table<Robot>()) { r -> r.ownerId == p.id }
           Triple(p, a, r)
@@ -233,7 +233,7 @@ class QuerySpec : FreeSpec({
 
   "joins" - {
     "Person, Address - join" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = join(Table<Address>()) { a -> a.ownerId == p.id }
         p to a
@@ -246,7 +246,7 @@ class QuerySpec : FreeSpec({
     }
 
     "Person, Address - left join" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
         p to a
@@ -260,7 +260,7 @@ class QuerySpec : FreeSpec({
     }
 
     "Person, Address - left-join + groupBy(name)" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
         groupBy(p.firstName)
@@ -273,7 +273,7 @@ class QuerySpec : FreeSpec({
     }
 
     "Person, Address - left-join + groupBy(name) + filter" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
         where { p.lastName == "Doggs" || p.lastName == "Roogs" }
@@ -287,7 +287,7 @@ class QuerySpec : FreeSpec({
     }
 
     "Person, address - left-join + groupBy(name) + filter + orderBy" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
         where { p.lastName == "Doggs" || p.lastName == "Roogs" }

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/mysql/ActionOnConflictSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/mysql/ActionOnConflictSpec.kt
@@ -2,13 +2,13 @@ package io.exoquery.mysql
 
 import io.exoquery.testdata.Person
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.insertPerson
 import io.exoquery.joe
 import io.exoquery.people
 import io.exoquery.runOn
-import io.exoquery.sql.MySqlDialect
+import io.exoquery.MySqlDialect
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
@@ -31,7 +31,7 @@ class ActionOnConflictSpec : FreeSpec({
       ctx.insertPerson(joe)
       val nameVar = "Joee"
       val lastNameVar = "Bloggsee"
-      val q = capture {
+      val q = sql {
         insert<Person> {
           set(id to param(joe.id), firstName to param(nameVar), lastName to param(lastNameVar), age to 1234)
             .onConflictUpdate(id) { excluding -> set(firstName to firstName + "_" + excluding.firstName, lastName to lastName + "_" + excluding.lastName, age to excluding.age) }
@@ -45,7 +45,7 @@ class ActionOnConflictSpec : FreeSpec({
     //  ctx.insertPerson(joe)
     //  val nameVar = "Joee"
     //  val lastNameVar = "Bloggsee"
-    //  val q = capture {
+    //  val q = sql {
     //    insert<Person> {
     //      set(id to param(joe.id), firstName to param(nameVar), lastName to param(lastNameVar), age to 1234)
     //        .onConflictUpdate(id) { excluding -> set(firstName to firstName + "_" + excluding.firstName, lastName to lastName + "_" + excluding.lastName, age to excluding.age) }
@@ -60,7 +60,7 @@ class ActionOnConflictSpec : FreeSpec({
       ctx.insertPerson(joe)
       val nameVar = "Joee"
       val lastNameVar = "Bloggsee"
-      val q = capture {
+      val q = sql {
         insert<Person> {
           set(id to param(joe.id), firstName to param(nameVar), lastName to param(lastNameVar), age to 1234)
             .onConflictIgnore()

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/mysql/ActionSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/mysql/ActionSpec.kt
@@ -1,9 +1,9 @@
 package io.exoquery.mysql
 
 import io.exoquery.testdata.Person
-import io.exoquery.sql.MySqlDialect
+import io.exoquery.MySqlDialect
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.jdbc.JdbcController
 import io.exoquery.controller.runActions
 import io.exoquery.joe
@@ -29,28 +29,28 @@ class ActionSpec : FreeSpec({
 
   "insert" - {
     "simple" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }
       }
       q.build<MySqlDialect>().runOn(ctx) shouldBe 1
       ctx.people() shouldBe listOf(joe)
     }
     "simple with params" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to param("Joe"), lastName to param("Bloggs"), age to param(111)) }
       }
       q.build<MySqlDialect>().runOn(ctx) shouldBe 1
       ctx.people() shouldBe listOf(joe)
     }
     "simple with setParams" {
-      val q = capture {
+      val q = sql {
         insert<Person> { setParams(Person(1, "Joe", "Bloggs", 111)) }
       }
       q.build<MySqlDialect>().runOn(ctx) shouldBe 1
       ctx.people() shouldBe listOf(joe)
     }
     "simple with setParams and exclusion" {
-      val q = capture {
+      val q = sql {
         insert<Person> { setParams(Person(1, "Joe", "Bloggs", 111)).excluding(id) }
       }
       q.build<MySqlDialect>().runOn(ctx) shouldBe 1
@@ -58,7 +58,7 @@ class ActionSpec : FreeSpec({
     }
     // Not supported in MySQL
     //"with returning" {
-    //  val q = capture {
+    //  val q = sql {
     //    insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id + 100 }
     //  }
     //  val build = q.build<MySqlDialect>()
@@ -67,7 +67,7 @@ class ActionSpec : FreeSpec({
     //}
     //"with returning using param" {
     //  val n = 1000
-    //  val q = capture {
+    //  val q = sql {
     //    insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id + 100 + param(n) }
     //  }
     //  val build = q.build<MySqlDialect>()
@@ -75,7 +75,7 @@ class ActionSpec : FreeSpec({
     //  ctx.people() shouldBe listOf(joe)
     //}
     //"with returning - multiple" {
-    //  val q = capture {
+    //  val q = sql {
     //    insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id to p.firstName }
     //  }
     //  val build = q.build<MySqlDialect>()
@@ -83,7 +83,7 @@ class ActionSpec : FreeSpec({
     //  ctx.people() shouldBe listOf(joe)
     //}
     "with returning keys" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returningKeys { id }
       }
       val build = q.build<MySqlDialect>()
@@ -92,7 +92,7 @@ class ActionSpec : FreeSpec({
     }
     // Not valid because firstName is not an inserted value
     //"with returning keys multiple" {
-    //  val q = capture {
+    //  val q = sql {
     //    insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returningKeys { id to firstName }
     //  }
     //  val build = q.build<MySqlDialect>()
@@ -116,7 +116,7 @@ class ActionSpec : FreeSpec({
   "update" - {
     "simple" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }
       }
       q.build<MySqlDialect>().runOn(ctx) shouldBe 1
@@ -124,7 +124,7 @@ class ActionSpec : FreeSpec({
     }
     "no condition" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         update<Person> { set(firstName to param("Joe"), lastName to param("Bloggs"), age to 111) }.all()
       }
       q.build<MySqlDialect>().runOn(ctx) shouldBe 2
@@ -136,7 +136,7 @@ class ActionSpec : FreeSpec({
     "with setParams" {
       ctx.insertGeorgeAndJim()
       val updateCall = Person(1, "Joe", "Bloggs", 111)
-      val q = capture {
+      val q = sql {
         // TODO need to make a warning when this situation happens, can't have param instances here
         // update<Person> { setParams(Person(1, param("Joe"), param("Bloggs"), 111)) }.filter { p -> p.id == 1 }
         update<Person> { setParams(updateCall) }.filter { p -> p.id == 1 }
@@ -148,7 +148,7 @@ class ActionSpec : FreeSpec({
       ctx.insertGeorgeAndJim()
       // Set a large Id that should specifically be excluded from insertion
       val updateCall = Person(1000, "Joe", "Bloggs", 111)
-      val q = capture {
+      val q = sql {
         // Set the ID to 0 so we can be sure
         update<Person> { setParams(updateCall).excluding(id) }.filter { p -> p.id == 1 }
       }
@@ -158,7 +158,7 @@ class ActionSpec : FreeSpec({
     // Not supported in MySQL
     //"with returning" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returning { p -> p.id + 100 }
     //  }
     //  val build = q.build<MySqlDialect>()
@@ -167,7 +167,7 @@ class ActionSpec : FreeSpec({
     //}
     //"with returning - multiple" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returning { p -> p.id to p.firstName }
     //  }
     //  val build = q.build<MySqlDialect>()
@@ -176,7 +176,7 @@ class ActionSpec : FreeSpec({
     //}
     //"with returningKeys" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returningKeys { id }
     //  }
     //  val build = q.build<MySqlDialect>()
@@ -188,7 +188,7 @@ class ActionSpec : FreeSpec({
   "delete" - {
     "simple" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         delete<Person>().filter { p -> p.id == 1 }
       }
       q.build<MySqlDialect>().runOn(ctx) shouldBe 1
@@ -196,7 +196,7 @@ class ActionSpec : FreeSpec({
     }
     "no condition" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         delete<Person>().all()
       }
       q.build<MySqlDialect>().runOn(ctx) shouldBe 2
@@ -205,7 +205,7 @@ class ActionSpec : FreeSpec({
     // Not supported in MySQL
     //"with returning" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    delete<Person>().filter { p -> p.id == 1 }.returning { p -> p.id + 100 }
     //  }
     //  val build = q.build<MySqlDialect>()
@@ -214,7 +214,7 @@ class ActionSpec : FreeSpec({
     //}
     //"with returningKeys" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    delete<Person>().filter { p -> p.id == 1 }.returningKeys { id }
     //  }
     //  val build = q.build<MySqlDialect>()

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/mysql/CastingSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/mysql/CastingSpec.kt
@@ -1,8 +1,7 @@
 package io.exoquery.mysql
 
-import io.exoquery.SqlQuery
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.runOn
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
@@ -11,32 +10,32 @@ class CastingSpec : FreeSpec({
   val ctx = TestDatabases.mysql
 
   "Int to String" {
-    val q = capture.select { 1.toString() }
+    val q = sql.select { 1.toString() }
     q.buildFor.MySql().runOn(ctx).first() shouldBe "1"
   }
 
   "String to Long" {
-    val q = capture.select { "1".toLong() }
+    val q = sql.select { "1".toLong() }
     q.buildFor.MySql().runOn(ctx).first() shouldBe 1
   }
   "String to Int" {
-    val q = capture.select { "1".toInt() }
+    val q = sql.select { "1".toInt() }
     q.buildFor.MySql().runOn(ctx).first() shouldBe 1
   }
   "String to Short" {
-    val q = capture.select { "1".toShort() }
+    val q = sql.select { "1".toShort() }
     q.buildFor.MySql().runOn(ctx).first() shouldBe 1
   }
   "String to Double" {
-    val q = capture.select { "1.2".toDouble() }
+    val q = sql.select { "1.2".toDouble() }
     q.buildFor.MySql().runOn(ctx).first() shouldBe (1.2).toDouble()
   }
   "String to Float" {
-    val q = capture.select { "1.2".toFloat() }
+    val q = sql.select { "1.2".toFloat() }
     q.buildFor.MySql().runOn(ctx).first() shouldBe (1.2).toFloat()
   }
   "String to Boolean" {
-    val q = capture.select { "true".toBoolean() }
+    val q = sql.select { "true".toBoolean() }
     q.buildFor.MySql().runOn(ctx).first() shouldBe true
   }
 })

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/ActionOnConflictSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/ActionOnConflictSpec.kt
@@ -2,13 +2,13 @@ package io.exoquery.postgres
 
 import io.exoquery.testdata.Person
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.insertPerson
 import io.exoquery.joe
 import io.exoquery.people
 import io.exoquery.runOn
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
@@ -30,7 +30,7 @@ class ActionOnConflictSpec : FreeSpec({
       ctx.insertPerson(joe)
       val nameVar = "Joee"
       val lastNameVar = "Bloggsee"
-      val q = capture {
+      val q = sql {
         insert<Person> {
           set(id to param(joe.id), firstName to param(nameVar), lastName to param(lastNameVar), age to 1234)
             .onConflictUpdate(id) { excluding -> set(firstName to firstName + "_" + excluding.firstName, lastName to lastName + "_" + excluding.lastName, age to excluding.age) }
@@ -43,7 +43,7 @@ class ActionOnConflictSpec : FreeSpec({
       ctx.insertPerson(joe)
       val nameVar = "Joee"
       val lastNameVar = "Bloggsee"
-      val q = capture {
+      val q = sql {
         insert<Person> {
           set(id to param(joe.id), firstName to param(nameVar), lastName to param(lastNameVar), age to 1234)
             .onConflictUpdate(id) { excluding -> set(firstName to firstName + "_" + excluding.firstName, lastName to lastName + "_" + excluding.lastName, age to excluding.age) }
@@ -58,7 +58,7 @@ class ActionOnConflictSpec : FreeSpec({
       ctx.insertPerson(joe)
       val nameVar = "Joee"
       val lastNameVar = "Bloggsee"
-      val q = capture {
+      val q = sql {
         insert<Person> {
           set(id to param(joe.id), firstName to param(nameVar), lastName to param(lastNameVar), age to 1234)
             .onConflictIgnore(id)

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/AggSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/AggSpec.kt
@@ -1,18 +1,13 @@
 package io.exoquery.postgres
 
-import io.exoquery.testdata.Address
-import io.exoquery.Ord
 import io.exoquery.testdata.Person
-import io.exoquery.sql.PostgresDialect
-import io.exoquery.testdata.Robot
+import io.exoquery.PostgresDialect
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.jdbc.runOn
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
-import kotlinx.serialization.Serializable
 import kotlin.to
 
 
@@ -35,7 +30,7 @@ class AggSpec : FreeSpec({
   }
 
   "simple" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       groupBy(p.firstName)
       having { avg(p.age) < 100 }

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/CastingSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/CastingSpec.kt
@@ -1,8 +1,7 @@
 package io.exoquery.postgres
 
-import io.exoquery.SqlQuery
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.runOn
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
@@ -11,32 +10,32 @@ class CastingSpec : FreeSpec({
   val ctx = TestDatabases.postgres
 
   "Int to String" {
-    val q = capture.select { 1.toString() }
+    val q = sql.select { 1.toString() }
     q.buildFor.Postgres().runOn(ctx).first() shouldBe "1"
   }
 
   "String to Long" {
-    val q = capture.select { "1".toLong() }
+    val q = sql.select { "1".toLong() }
     q.buildFor.Postgres().runOn(ctx).first() shouldBe 1
   }
   "String to Int" {
-    val q = capture.select { "1".toInt() }
+    val q = sql.select { "1".toInt() }
     q.buildFor.Postgres().runOn(ctx).first() shouldBe 1
   }
   "String to Short" {
-    val q = capture.select { "1".toShort() }
+    val q = sql.select { "1".toShort() }
     q.buildFor.Postgres().runOn(ctx).first() shouldBe 1
   }
   "String to Double" {
-    val q = capture.select { "1.2".toDouble() }
+    val q = sql.select { "1.2".toDouble() }
     q.buildFor.Postgres().runOn(ctx).first() shouldBe (1.2).toDouble()
   }
   "String to Float" {
-    val q = capture.select { "1.2".toFloat() }
+    val q = sql.select { "1.2".toFloat() }
     q.buildFor.Postgres().runOn(ctx).first() shouldBe (1.2).toFloat()
   }
   "String to Boolean" {
-    val q = capture.select { "true".toBoolean() }
+    val q = sql.select { "true".toBoolean() }
     q.buildFor.Postgres().runOn(ctx).first() shouldBe true
   }
 })

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/CodegenSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/CodegenSpec.kt
@@ -6,7 +6,7 @@ import io.kotest.core.spec.style.FreeSpec
 class CodegenSpec : FreeSpec({
   val ctx = TestDatabases.postgres
 
-  //capture.generate(
+  //sql.generate(
   //  Code.Entities(
   //    "v1",
   //    DatabaseDriver.Postgres(),

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/CustomEncodingSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/CustomEncodingSpec.kt
@@ -3,10 +3,10 @@ package io.exoquery.postgres
 import io.exoquery.TestDatabases
 import io.exoquery.annotation.ExoField
 import io.exoquery.annotation.ExoValue
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.jdbc.runOn
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import kotlinx.serialization.KSerializer
@@ -66,13 +66,13 @@ class CustomEncodingSpec : FreeSpec({
         Person(3, FirstName("John"), "Smith", 40)
       )
 
-      val q = capture.batch(insertPeople.asSequence()) { p ->
+      val q = sql.batch(insertPeople.asSequence()) { p ->
         insert<Person> { setParams(p) }
       }
       q.build<PostgresDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 1, 1)
 
       val retrievePeople =
-        capture {
+        sql {
           Table<Person>()
         }
       retrievePeople.build<PostgresDialect>().runOn(ctx) shouldContainExactlyInAnyOrder insertPeople
@@ -94,13 +94,13 @@ class CustomEncodingSpec : FreeSpec({
         Person(3, FirstName("John"), "Smith", 40)
       )
 
-      val q = capture.batch(insertPeople.asSequence()) { p ->
+      val q = sql.batch(insertPeople.asSequence()) { p ->
         insert<Person> { setParams(p) }
       }
       q.build<PostgresDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 1, 1)
 
       val retrievePeople =
-        capture {
+        sql {
           Table<Person>()
         }
       retrievePeople.build<PostgresDialect>().runOn(ctx) shouldContainExactlyInAnyOrder insertPeople
@@ -122,13 +122,13 @@ class CustomEncodingSpec : FreeSpec({
         Person(3, FirstNameAnnotated("John"), "Smith", 40)
       )
 
-      val q = capture.batch(insertPeople.asSequence()) { p ->
+      val q = sql.batch(insertPeople.asSequence()) { p ->
         insert<Person> { setParams(p) }
       }
       q.build<PostgresDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 1, 1)
 
       val retrievePeople =
-        capture {
+        sql {
           Table<Person>()
         }
       retrievePeople.build<PostgresDialect>().runOn(ctx) shouldContainExactlyInAnyOrder insertPeople

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/DynamicActionSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/DynamicActionSpec.kt
@@ -1,12 +1,11 @@
 package io.exoquery.postgres
 
 import io.exoquery.testdata.Person
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.SqlExpression
 import io.exoquery.TestDatabases
 import io.exoquery.annotation.CapturedDynamic
-import io.exoquery.capture
-import io.exoquery.controller.jdbc.JdbcController
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.george
 import io.exoquery.insertAllPeople
@@ -36,16 +35,16 @@ class DynamicActionSpec : FreeSpec({
     @CapturedDynamic
     fun conditionClause(p: SqlExpression<Person>) =
       namesToModify
-        .map { n -> capture.expression { p.use.lastName == param(n) } }
-        .reduce { a, b -> capture.expression { a.use || b.use } }
+        .map { n -> sql.expression { p.use.lastName == param(n) } }
+        .reduce { a, b -> sql.expression { a.use || b.use } }
 
     ctx.insertAllPeople()
     val update =
-      capture {
+      sql {
         update<Person> {
           set(firstName to firstName + "-A")
         }.filter { p ->
-          conditionClause(capture.expression { p }).use
+          conditionClause(sql.expression { p }).use
         }
       }
 

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/FreeClauseSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/FreeClauseSpec.kt
@@ -3,9 +3,9 @@ package io.exoquery.postgres
 import io.exoquery.testdata.Person
 import io.exoquery.SqlAction
 import io.exoquery.SqlQuery
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.joe
 import io.exoquery.people
@@ -28,7 +28,7 @@ class FreeClauseSpec : FreeSpec({
   }
 
   "whole-body insert" {
-    val q = capture {
+    val q = sql {
       free("INSERT INTO Person (firstName, lastName, age) VALUES ('Joe', 'Bloggs', 111)")
         .asPure<SqlAction<Nothing, Long>>()
       //insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }
@@ -43,7 +43,7 @@ class FreeClauseSpec : FreeSpec({
       INSERT INTO Person (firstName, lastName, age) VALUES ('Joe', 'Bloggs', 111)
       """
     )
-    val q = capture {
+    val q = sql {
       free("SELECT * FROM Person WHERE firstName = 'Joe'")
         .asPure<SqlQuery<Person>>()
     }

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/TransactionSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/TransactionSpec.kt
@@ -1,12 +1,11 @@
 package io.exoquery.postgres
 
 import io.exoquery.testdata.Person
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.controller.transaction
-import io.exoquery.printSource
 import io.exoquery.jdbc.runOn
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
@@ -28,12 +27,12 @@ class TransactionSpec : FreeSpec({
   val jack = Person(2, "Jack", "Roogs", 222)
 
   suspend fun select() =
-    capture { Table<Person>() }.build<PostgresDialect>().runOn(ctx)
+    sql { Table<Person>() }.build<PostgresDialect>().runOn(ctx)
 
   "transaction support" - {
     "success" {
       ctx.transaction {
-        capture {
+        sql {
           insert<Person> { setParams(joe) }
         }.build<PostgresDialect>().runOnTransaction()
       }
@@ -42,12 +41,12 @@ class TransactionSpec : FreeSpec({
 
     "failure" {
       // Insert joe record
-      capture { insert<Person> { setParams(joe) } }.build<PostgresDialect>().runOn(ctx)
+      sql { insert<Person> { setParams(joe) } }.build<PostgresDialect>().runOn(ctx)
 
 
       shouldThrow<IllegalStateException> {
         ctx.transaction {
-          capture {
+          sql {
             insert<Person> { setParams(jack) }
           }.build<PostgresDialect>().runOnTransaction()
           throw IllegalStateException()
@@ -57,7 +56,7 @@ class TransactionSpec : FreeSpec({
     }
 
     "nested" {
-      val cap = capture {
+      val cap = sql {
         insert<Person> { setParams(joe) }
       }.build<PostgresDialect>()
 

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/WindowFunctionSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/postgres/WindowFunctionSpec.kt
@@ -1,11 +1,9 @@
 package io.exoquery.postgres
 
-import io.exoquery.testdata.Address
-import io.exoquery.Ord
 import io.exoquery.testdata.Person
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.jdbc.runOn
 import io.kotest.core.spec.style.FreeSpec
@@ -33,7 +31,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "rank over partition by firstName order by lastName" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       p to over().partitionBy(p.firstName).sortBy(p.lastName).rank()
     }
@@ -46,7 +44,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "dense_rank over partition by firstName order by lastName" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       p to over().partitionBy(p.firstName).sortBy(p.lastName).rankDense()
     }
@@ -59,7 +57,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "row_number over partition by firstName order by lastName" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       p to over().partitionBy(p.firstName).sortBy(p.lastName).rowNumber()
     }
@@ -72,7 +70,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "sum over partition by firstName" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       Triple(p.firstName, p.lastName, over().partitionBy(p.firstName).sum(p.age))
     }
@@ -85,7 +83,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "avg over partition by firstName" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       Triple(p.firstName, p.lastName, over().partitionBy(p.firstName).avg(p.age))
     }
@@ -98,7 +96,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "min over partition by firstName" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       Triple(p.firstName, p.lastName, over().partitionBy(p.firstName).min(p.age))
     }
@@ -111,7 +109,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "max over partition by firstName" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       Triple(p.firstName, p.lastName, over().partitionBy(p.firstName).max(p.age))
     }
@@ -124,7 +122,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "count over partition by firstName" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       Triple(p.firstName, p.lastName, over().partitionBy(p.firstName).count())
     }
@@ -137,7 +135,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "lag over partition by firstName order by age" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       Triple(p.firstName, p.lastName, over().partitionBy(p.firstName).sortBy(p.age).lag(p.age))
     }
@@ -150,7 +148,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "lead over partition by firstName order by age" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       Triple(p.firstName, p.lastName, over().partitionBy(p.firstName).sortBy(p.age).lead(p.age))
     }
@@ -163,7 +161,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "first_value over partition by firstName order by age" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       Triple(p.firstName, p.lastName, over().partitionBy(p.firstName).sortBy(p.age).firstValue(p.age))
     }
@@ -176,7 +174,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "rank over orderBy lastName without partition" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       p to over().sortBy(p.lastName).rank()
     }
@@ -189,7 +187,7 @@ class WindowFunctionSpec : FreeSpec({
   }
 
   "count over without partition or ordering" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       Triple(p.firstName, p.lastName, over().count())
     }

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlite/ActionOnConflictSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlite/ActionOnConflictSpec.kt
@@ -3,13 +3,12 @@ package io.exoquery.sqlite
 import io.exoquery.SqliteDialect
 import io.exoquery.testdata.Person
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.insertPerson
 import io.exoquery.joe
 import io.exoquery.people
 import io.exoquery.runOn
-import io.exoquery.sql.PostgresDialect
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
@@ -32,7 +31,7 @@ class ActionOnConflictSpec : FreeSpec({
       ctx.insertPerson(joe)
       val nameVar = "Joee"
       val lastNameVar = "Bloggsee"
-      val q = capture {
+      val q = sql {
         insert<Person> {
           set(id to param(joe.id), firstName to param(nameVar), lastName to param(lastNameVar), age to 1234)
             .onConflictUpdate(id) { excluding -> set(firstName to firstName + "_" + excluding.firstName, lastName to lastName + "_" + excluding.lastName, age to excluding.age) }
@@ -45,7 +44,7 @@ class ActionOnConflictSpec : FreeSpec({
       ctx.insertPerson(joe)
       val nameVar = "Joee"
       val lastNameVar = "Bloggsee"
-      val q = capture {
+      val q = sql {
         insert<Person> {
           set(id to param(joe.id), firstName to param(nameVar), lastName to param(lastNameVar), age to 1234)
             .onConflictUpdate(id) { excluding -> set(firstName to firstName + "_" + excluding.firstName, lastName to lastName + "_" + excluding.lastName, age to excluding.age) }
@@ -60,7 +59,7 @@ class ActionOnConflictSpec : FreeSpec({
       ctx.insertPerson(joe)
       val nameVar = "Joee"
       val lastNameVar = "Bloggsee"
-      val q = capture {
+      val q = sql {
         insert<Person> {
           set(id to param(joe.id), firstName to param(nameVar), lastName to param(lastNameVar), age to 1234)
             .onConflictIgnore(id)

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlite/ActionSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlite/ActionSpec.kt
@@ -3,7 +3,7 @@ package io.exoquery.sqlite
 import io.exoquery.testdata.Person
 import io.exoquery.SqliteDialect
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.jdbc.JdbcController
 import io.exoquery.controller.runActions
 import io.exoquery.joe
@@ -30,35 +30,35 @@ class ActionSpec : FreeSpec({
 
   "insert" - {
     "simple" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }
       }
       q.build<SqliteDialect>().runOn(ctx) shouldBe 1
       ctx.people() shouldBe listOf(joe)
     }
     "simple with params" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to param("Joe"), lastName to param("Bloggs"), age to param(111)) }
       }
       q.build<SqliteDialect>().runOn(ctx) shouldBe 1
       ctx.people() shouldBe listOf(joe)
     }
     "simple with setParams" {
-      val q = capture {
+      val q = sql {
         insert<Person> { setParams(Person(1, "Joe", "Bloggs", 111)) }
       }
       q.build<SqliteDialect>().runOn(ctx) shouldBe 1
       ctx.people() shouldBe listOf(joe)
     }
     "simple with setParams and exclusion" {
-      val q = capture {
+      val q = sql {
         insert<Person> { setParams(Person(1, "Joe", "Bloggs", 111)).excluding(id) }
       }
       q.build<SqliteDialect>().runOn(ctx) shouldBe 1
       ctx.people() shouldBe listOf(joe)
     }
     "with returning" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id + 100 }
       }
       val build = q.build<SqliteDialect>()
@@ -67,7 +67,7 @@ class ActionSpec : FreeSpec({
     }
     "with returning using param" {
       val n = 1000
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id + 100 + param(n) }
       }
       val build = q.build<SqliteDialect>()
@@ -75,7 +75,7 @@ class ActionSpec : FreeSpec({
       ctx.people() shouldBe listOf(joe)
     }
     "with returning - multiple" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id to p.firstName }
       }
       val build = q.build<SqliteDialect>()
@@ -83,7 +83,7 @@ class ActionSpec : FreeSpec({
       ctx.people() shouldBe listOf(joe)
     }
     "with returning keys" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returningKeys { id }
       }
       val build = q.build<SqliteDialect>()
@@ -107,7 +107,7 @@ class ActionSpec : FreeSpec({
   "update" - {
     "simple" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }
       }
       q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -115,7 +115,7 @@ class ActionSpec : FreeSpec({
     }
     "no condition" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         update<Person> { set(firstName to param("Joe"), lastName to param("Bloggs"), age to 111) }.all()
       }
       q.build<SqliteDialect>().runOn(ctx) shouldBe 2
@@ -127,7 +127,7 @@ class ActionSpec : FreeSpec({
     "with setParams" {
       ctx.insertGeorgeAndJim()
       val updateCall = Person(1, "Joe", "Bloggs", 111)
-      val q = capture {
+      val q = sql {
         update<Person> { setParams(updateCall) }.filter { p -> p.id == 1 }
       }
       q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -136,7 +136,7 @@ class ActionSpec : FreeSpec({
     "with setParams and exclusion" {
       ctx.insertGeorgeAndJim()
       val updateCall = Person(1000, "Joe", "Bloggs", 111)
-      val q = capture {
+      val q = sql {
         update<Person> { setParams(updateCall).excluding(id) }.filter { p -> p.id == 1 }
       }
       q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -144,7 +144,7 @@ class ActionSpec : FreeSpec({
     }
     "with returning" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returning { p -> p.id + 100 }
       }
       val build = q.build<SqliteDialect>()
@@ -153,7 +153,7 @@ class ActionSpec : FreeSpec({
     }
     "with returning - multiple" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returning { p -> p.id to p.firstName }
       }
       val build = q.build<SqliteDialect>()
@@ -163,7 +163,7 @@ class ActionSpec : FreeSpec({
     // Not supported with UPDATE in Sqlite
     //"with returningKeys" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returningKeys { id }
     //  }
     //  val build = q.build<SqliteDialect>()
@@ -175,7 +175,7 @@ class ActionSpec : FreeSpec({
   "delete" - {
     "simple" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         delete<Person>().filter { p -> p.id == 1 }
       }
       q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -183,7 +183,7 @@ class ActionSpec : FreeSpec({
     }
     "no condition" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         delete<Person>().all()
       }
       q.build<SqliteDialect>().runOn(ctx) shouldBe 2
@@ -191,7 +191,7 @@ class ActionSpec : FreeSpec({
     }
     "with returning" {
       ctx.insertGeorgeAndJim()
-      val q = capture {
+      val q = sql {
         delete<Person>().filter { p -> p.id == 1 }.returning { p -> p.id + 100 }
       }
       val build = q.build<SqliteDialect>()
@@ -201,7 +201,7 @@ class ActionSpec : FreeSpec({
     // Not supported with DELETE in Sqlite
     //"with returningKeys" {
     //  ctx.insertGeorgeAndJim()
-    //  val q = capture {
+    //  val q = sql {
     //    delete<Person>().filter { p -> p.id == 1 }.returningKeys { id }
     //  }
     //  val build = q.build<SqliteDialect>()

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlite/CastingSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlite/CastingSpec.kt
@@ -1,8 +1,7 @@
 package io.exoquery.sqlite
 
-import io.exoquery.SqlQuery
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.runOn
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
@@ -11,32 +10,32 @@ class CastingSpec : FreeSpec({
   val ctx = TestDatabases.sqlite
 
   "Int to String" {
-    val q = capture.select { 1.toString() }
+    val q = sql.select { 1.toString() }
     q.buildFor.Sqlite().runOn(ctx).first() shouldBe "1"
   }
 
   "String to Long" {
-    val q = capture.select { "1".toLong() }
+    val q = sql.select { "1".toLong() }
     q.buildFor.Sqlite().runOn(ctx).first() shouldBe 1
   }
   "String to Int" {
-    val q = capture.select { "1".toInt() }
+    val q = sql.select { "1".toInt() }
     q.buildFor.Sqlite().runOn(ctx).first() shouldBe 1
   }
   "String to Short" {
-    val q = capture.select { "1".toShort() }
+    val q = sql.select { "1".toShort() }
     q.buildFor.Sqlite().runOn(ctx).first() shouldBe 1
   }
   "String to Double" {
-    val q = capture.select { "1.2".toDouble() }
+    val q = sql.select { "1.2".toDouble() }
     q.buildFor.Sqlite().runOn(ctx).first() shouldBe (1.2).toDouble()
   }
   "String to Float" {
-    val q = capture.select { "1.2".toFloat() }
+    val q = sql.select { "1.2".toFloat() }
     q.buildFor.Sqlite().runOn(ctx).first() shouldBe (1.2).toFloat()
   }
   "String to Boolean" {
-    val q = capture.select { "true".toBoolean() }
+    val q = sql.select { "true".toBoolean() }
     q.buildFor.Sqlite().runOn(ctx).first() shouldBe true
   }
 })

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlite/QuerySpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlite/QuerySpec.kt
@@ -6,7 +6,7 @@ import io.exoquery.testdata.Person
 import io.exoquery.SqliteDialect
 import io.exoquery.testdata.Robot
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.jdbc.runOn
 import io.kotest.core.spec.style.FreeSpec
@@ -38,7 +38,7 @@ class QuerySpec : FreeSpec({
   }
 
   "simple" {
-    val q = capture { Table<Person>() }
+    val q = sql { Table<Person>() }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222),
@@ -47,7 +47,7 @@ class QuerySpec : FreeSpec({
   }
 
   "filter" {
-    val q = capture { Table<Person>().filter { it.firstName == "Joe" } }
+    val q = sql { Table<Person>().filter { it.firstName == "Joe" } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -56,7 +56,7 @@ class QuerySpec : FreeSpec({
 
   "filter with param" {
     val joe = "Joe"
-    val q = capture { Table<Person>().filter { it.firstName == param(joe) } }
+    val q = sql { Table<Person>().filter { it.firstName == param(joe) } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -64,7 +64,7 @@ class QuerySpec : FreeSpec({
   }
 
   "where" {
-    val q = capture { Table<Person>().where { firstName == "Joe" } }
+    val q = sql { Table<Person>().where { firstName == "Joe" } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -72,7 +72,7 @@ class QuerySpec : FreeSpec({
   }
 
   "filter + sortedBy" {
-    val q = capture { Table<Person>().filter { it.firstName == "Joe" }.sortedBy { it.age } }
+    val q = sql { Table<Person>().filter { it.firstName == "Joe" }.sortedBy { it.age } }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -80,7 +80,7 @@ class QuerySpec : FreeSpec({
   }
 
   "filter + correlated isNotEmpty" {
-    val q = capture { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isNotEmpty() } }
+    val q = sql { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isNotEmpty() } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -88,21 +88,21 @@ class QuerySpec : FreeSpec({
   }
 
   "filter + correlated isEmpty" {
-    val q = capture { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isEmpty() } }
+    val q = sql { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isEmpty() } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(3, "Jim", "Roogs", 333)
     )
   }
 
   "sort + take" {
-    val q = capture { Table<Person>().sortedBy { it.age }.take(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.take(1) }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(1, "Joe", "Bloggs", 111)
     )
   }
 
   "sort + drop" {
-    val q = capture { Table<Person>().sortedBy { it.age }.drop(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.drop(1) }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(2, "Joe", "Doggs", 222),
       Person(3, "Jim", "Roogs", 333)
@@ -110,7 +110,7 @@ class QuerySpec : FreeSpec({
   }
 
   "distinct" {
-    val q = capture { Table<Person>().map { it.firstName }.distinct() }
+    val q = sql { Table<Person>().map { it.firstName }.distinct() }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       "Joe",
       "Jim"
@@ -119,7 +119,7 @@ class QuerySpec : FreeSpec({
 
   // Does not exist in Sqlite
   //"distinctOn" {
-  //  val q = capture { Table<Person>().distinctOn { it.firstName } }
+  //  val q = sql { Table<Person>().distinctOn { it.firstName } }
   //  q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
   //    Person(1, "Joe", "Bloggs", 111),
   //    Person(3, "Jim", "Roogs", 333)
@@ -127,14 +127,14 @@ class QuerySpec : FreeSpec({
   //}
 
   "sort + drop + take" {
-    val q = capture { Table<Person>().sortedBy { it.age }.drop(1).take(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.drop(1).take(1) }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(2, "Joe", "Doggs", 222)
     )
   }
 
   "map" {
-    val q = capture { Table<Person>().map { it.firstName to it.lastName } }
+    val q = sql { Table<Person>().map { it.firstName to it.lastName } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       "Joe" to "Bloggs",
       "Joe" to "Doggs",
@@ -149,7 +149,7 @@ class QuerySpec : FreeSpec({
   data class CustomPerson(val name: Name, val age: Int)
 
   "map to custom" {
-    val q = capture { Table<Person>().map { CustomPerson(Name(it.firstName, it.lastName), it.age) } }
+    val q = sql { Table<Person>().map { CustomPerson(Name(it.firstName, it.lastName), it.age) } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       CustomPerson(Name("Joe", "Bloggs"), 111),
       CustomPerson(Name("Joe", "Doggs"), 222),
@@ -158,7 +158,7 @@ class QuerySpec : FreeSpec({
   }
 
   "nested" {
-    val q = capture { Table<Person>().nested() }
+    val q = sql { Table<Person>().nested() }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222),
@@ -167,9 +167,9 @@ class QuerySpec : FreeSpec({
   }
 
   "union" {
-    val bloggs = capture { Table<Person>().filter { it.lastName == "Bloggs" } }
-    val doggs = capture { Table<Person>().filter { it.lastName == "Doggs" } }
-    val q = capture { bloggs union doggs }
+    val bloggs = sql { Table<Person>().filter { it.lastName == "Bloggs" } }
+    val doggs = sql { Table<Person>().filter { it.lastName == "Doggs" } }
+    val q = sql { bloggs union doggs }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -178,11 +178,11 @@ class QuerySpec : FreeSpec({
 
   "deconstruct" - {
     "columns - from a table" {
-      val names = capture.select {
+      val names = sql.select {
         val p = from(Table<Person>())
         p.firstName to p.lastName
       }
-      val q = capture.select {
+      val q = sql.select {
         val (first, last) = from(names)
         first + " - " + last
       }
@@ -194,11 +194,11 @@ class QuerySpec : FreeSpec({
     }
 
     "columns - from a table - mapped" {
-      val names = capture.select {
+      val names = sql.select {
         val p = from(Table<Person>())
         p.firstName to p.lastName
       }
-      val q = capture {
+      val q = sql {
         names.map { (first, last) -> first + " - " + last }
       }
       q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
@@ -210,13 +210,13 @@ class QuerySpec : FreeSpec({
 
     "join - from a join" {
       val join =
-        capture.select {
+        sql.select {
           val p = from(Table<Person>())
           val a = join(Table<Address>()) { a -> a.ownerId == p.id }
           p to a
         }
       val deconstuct =
-        capture.select {
+        sql.select {
           val (p, a) = from(join)
           val r = join(Table<Robot>()) { r -> r.ownerId == p.id }
           Triple(p, a, r)
@@ -234,7 +234,7 @@ class QuerySpec : FreeSpec({
 
   "joins" - {
     "Person, Address - join" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = join(Table<Address>()) { a -> a.ownerId == p.id }
         p to a
@@ -247,7 +247,7 @@ class QuerySpec : FreeSpec({
     }
 
     "Person, Address - left join" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
         p to a
@@ -261,7 +261,7 @@ class QuerySpec : FreeSpec({
     }
 
     "Person, Address - left-join + groupBy(name)" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
         groupBy(p.firstName)
@@ -274,7 +274,7 @@ class QuerySpec : FreeSpec({
     }
 
     "Person, Address - left-join + groupBy(name) + filter" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
         where { p.lastName == "Doggs" || p.lastName == "Roogs" }
@@ -288,7 +288,7 @@ class QuerySpec : FreeSpec({
     }
 
     "Person, address - left-join + groupBy(name) + filter + orderBy" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
         where { p.lastName == "Doggs" || p.lastName == "Roogs" }

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlserver/BatchActionSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlserver/BatchActionSpec.kt
@@ -1,26 +1,23 @@
 package io.exoquery.sqlserver
 
 import io.exoquery.testdata.Person
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.SqlAction
-import io.exoquery.sql.SqlServerDialect
+import io.exoquery.SqlServerDialect
 import io.exoquery.TestDatabases
 import io.exoquery.allPeople
-import io.exoquery.annotation.CapturedFunction
 import io.exoquery.batchDeletePeople
 import io.exoquery.batchInsertPeople
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.jdbc.JdbcController
 import io.exoquery.controller.runActions
 import io.exoquery.george
-import io.exoquery.insertAllPeople
 import io.exoquery.insertPerson
 import io.exoquery.joe
 import io.exoquery.people
 import io.exoquery.jdbc.runOn
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
-import io.kotest.matchers.shouldBe
 
 class BatchActionSpec : FreeSpec({
   val ctx = TestDatabases.sqlServer
@@ -39,7 +36,7 @@ class BatchActionSpec : FreeSpec({
 
     "simple" {
       ctx.insertPerson(joe)
-      val q = capture.batch(batchInsertPeople.asSequence()) { p ->
+      val q = sql.batch(batchInsertPeople.asSequence()) { p ->
         insert<Person> { set(firstName to param(p.firstName), lastName to param(p.lastName), age to param(p.age)) }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 1, 1)
@@ -49,13 +46,13 @@ class BatchActionSpec : FreeSpec({
     // TODO Catpured functions are not allowed to return SqlActions instances yet. Need to do some refactoring to allow this.
     //@CapturedFunction
     //fun <T> SqlAction<Person, T>.allowIdentityInsert() =
-    //  capture {
+    //  sql {
     //    free("SET IDENTITY_INSERT Person ON\n${this}\nSET IDENTITY_INSERT Person OFF").asPure<SqlAction<Person, T>>()
     //  }
 
     "simple with setParams" {
       ctx.insertPerson(joe)
-      val q = capture.batch(batchInsertPeople.asSequence()) { p ->
+      val q = sql.batch(batchInsertPeople.asSequence()) { p ->
         free("SET IDENTITY_INSERT Person ON\n${insert<Person> { setParams(p) }}\nSET IDENTITY_INSERT Person OFF").asPure<SqlAction<Person, Long>>()
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 1, 1)
@@ -66,7 +63,7 @@ class BatchActionSpec : FreeSpec({
       ctx.insertPerson(joe)
       // Modify the ids to make sure it is inserting records with a new Id, not the ones used here
       val insertPeople = batchInsertPeople.map { it.copy(id = it.id + 100) }.asSequence()
-      val q = capture.batch(insertPeople) { p ->
+      val q = sql.batch(insertPeople) { p ->
         insert<Person> { setParams(p).excluding(id) }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 1, 1)
@@ -75,7 +72,7 @@ class BatchActionSpec : FreeSpec({
 
     "with returning" {
       ctx.insertPerson(joe)
-      val q = capture.batch(batchInsertPeople.asSequence()) { p ->
+      val q = sql.batch(batchInsertPeople.asSequence()) { p ->
         insert<Person> { set(firstName to param(p.firstName), lastName to param(p.lastName), age to param(p.age)) }.returning { p -> p.id + 100 }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(102, 103, 104)
@@ -84,7 +81,7 @@ class BatchActionSpec : FreeSpec({
 
     "with returning and params" {
       ctx.insertPerson(joe)
-      val q = capture.batch(batchInsertPeople.asSequence()) { p ->
+      val q = sql.batch(batchInsertPeople.asSequence()) { p ->
         insert<Person> { set(firstName to param(p.firstName), lastName to param(p.lastName), age to param(p.age)) }.returning { pp -> pp.id + 100 to param(p.firstName) }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf((102 to "Joe"), (103 to "Jim"), (104 to "George"))
@@ -92,7 +89,7 @@ class BatchActionSpec : FreeSpec({
     }
     "with returning keys" {
       ctx.insertPerson(joe)
-      val q = capture.batch(batchInsertPeople.asSequence()) { p ->
+      val q = sql.batch(batchInsertPeople.asSequence()) { p ->
         insert<Person> { set(firstName to param(p.firstName), lastName to param(p.lastName), age to param(p.age)) }.returningKeys { id }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(2, 3, 4)
@@ -103,7 +100,7 @@ class BatchActionSpec : FreeSpec({
   // Override this for SqlServer since we need to set IDENTITY_INSERT ON
   suspend fun JdbcController.insertAllPeople() =
     allPeople.forEach {
-      capture {
+      sql {
         free("SET IDENTITY_INSERT Person ON\n${insert<Person> { setParams(it) }}\nSET IDENTITY_INSERT Person OFF").asPure<SqlAction<Person, Long>>()
       }.build<PostgresDialect>().runOn(this)
     }
@@ -114,7 +111,7 @@ class BatchActionSpec : FreeSpec({
 
     "simple" {
       ctx.insertAllPeople()
-      val q = capture.batch(updatedPeople.asSequence()) { p ->
+      val q = sql.batch(updatedPeople.asSequence()) { p ->
         update<Person> { set(firstName to param(p.firstName), lastName to param(p.lastName), age to param(p.age)) }.filter { pp -> pp.id == param(p.id) }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 1, 1)
@@ -124,7 +121,7 @@ class BatchActionSpec : FreeSpec({
     "simple with setParams and exclusion" {
       ctx.insertAllPeople()
       val peopleWithOddIds = updatedPeople.asSequence().map { it.copy(id = it.id + 100) }
-      val q = capture.batch(peopleWithOddIds) { p ->
+      val q = sql.batch(peopleWithOddIds) { p ->
         update<Person> { setParams(p).excluding(id) }.filter { pp -> pp.lastName == param(p.lastName) }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 1, 1)
@@ -134,7 +131,7 @@ class BatchActionSpec : FreeSpec({
     "simple with setParams and exclusion and returning param" {
       ctx.insertAllPeople()
       val peopleWithOddIds = updatedPeople.asSequence().map { it.copy(id = it.id + 100) }
-      val q = capture.batch(peopleWithOddIds) { p ->
+      val q = sql.batch(peopleWithOddIds) { p ->
         update<Person> { setParams(p).excluding(id) }.filter { pp -> pp.lastName == param(p.lastName) }.returning { pp -> pp.id to param(p.firstName) }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1 to "Joe-A", 2 to "Joe-A", 3 to "Jim-A")
@@ -144,7 +141,7 @@ class BatchActionSpec : FreeSpec({
     // Not supported in SqlServer
     //"returningKeys" {
     //  ctx.insertAllPeople()
-    //  val q = capture.batch(updatedPeople.asSequence()) { p ->
+    //  val q = sql.batch(updatedPeople.asSequence()) { p ->
     //    update<Person> { set(firstName to param(p.firstName), lastName to param(p.lastName), age to param(p.age)) }.filter { pp -> pp.id == param(p.id) }.returningKeys { id }
     //  }
     //  q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 2, 3)
@@ -158,7 +155,7 @@ class BatchActionSpec : FreeSpec({
 
     "simple" {
       ctx.insertAllPeople()
-      val q = capture.batch(ids) { id ->
+      val q = sql.batch(ids) { id ->
         delete<Person>().filter { pp -> pp.id == param(id) }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 1, 1)
@@ -167,7 +164,7 @@ class BatchActionSpec : FreeSpec({
 
     "using whole object" {
       ctx.insertAllPeople()
-      val q = capture.batch(batchDeletePeople.asSequence()) { p ->
+      val q = sql.batch(batchDeletePeople.asSequence()) { p ->
         delete<Person>().filter { pp -> pp.id == param(p.id) }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 1, 1)
@@ -176,7 +173,7 @@ class BatchActionSpec : FreeSpec({
 
     "with returning" {
       ctx.insertAllPeople()
-      val q = capture.batch(ids) { id ->
+      val q = sql.batch(ids) { id ->
         delete<Person>().filter { pp -> pp.id == param(id) }.returning { pp -> pp.id }
       }
       q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 2, 3)
@@ -186,7 +183,7 @@ class BatchActionSpec : FreeSpec({
     // Not supported in SqlServer
     //"with returning keys" {
     //  ctx.insertAllPeople()
-    //  val q = capture.batch(ids) { pid ->
+    //  val q = sql.batch(ids) { pid ->
     //    delete<Person>().filter { pp -> pp.id == param(pid) }.returningKeys { id }
     //  }
     //  q.build<SqlServerDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(1, 2, 3)

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlserver/BooleanLiteralSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlserver/BooleanLiteralSpec.kt
@@ -1,19 +1,12 @@
 package io.exoquery.sqlserver
 
-import io.exoquery.Ord
 import io.exoquery.TestDatabases
-import io.exoquery.capture
-import io.exoquery.capture.invoke
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.jdbc.runOn
-import io.exoquery.sql.SqlServerDialect
-import io.exoquery.testdata.Address
 import io.exoquery.testdata.Person
-import io.exoquery.testdata.Robot
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import kotlinx.serialization.Serializable
 
 class BooleanLiteralSpec : FreeSpec({
   val ctx = TestDatabases.sqlServer
@@ -29,7 +22,7 @@ class BooleanLiteralSpec : FreeSpec({
   }
 
   "where - simple" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       where { param(true) }
       p.firstName
@@ -38,7 +31,7 @@ class BooleanLiteralSpec : FreeSpec({
   }
 
   "where - combined" {
-    val q = capture.select {
+    val q = sql.select {
       val e = from(Table<Person>())
       where { param(true) || e.firstName == "Joe" }
       e.firstName
@@ -47,7 +40,7 @@ class BooleanLiteralSpec : FreeSpec({
   }
 
   "where - combined complex A" {
-    val q = capture.select {
+    val q = sql.select {
       val e = from(Table<Person>())
       where { param(false) || if (param(false)) param(false) || param(false) else e.firstName == "Joe" }
       e.firstName
@@ -56,7 +49,7 @@ class BooleanLiteralSpec : FreeSpec({
   }
 
   "where - combined complex A - false" {
-    val q = capture.select {
+    val q = sql.select {
       val e = from(Table<Person>())
       where { param(false) || if (param(false)) param(false) || param(false) else e.firstName == "Jack" }
       e.firstName
@@ -65,7 +58,7 @@ class BooleanLiteralSpec : FreeSpec({
   }
 
   "where - combined complex C" {
-    val q = capture.select {
+    val q = sql.select {
       val e = from(Table<Person>())
       where { param(false) || if (param(true)) param(false) || param(true) else e.firstName == "Jack" }
       e.firstName
@@ -75,7 +68,7 @@ class BooleanLiteralSpec : FreeSpec({
 
   "exists - lifted complex - notnull->false->true" {
     val nullableBool: Boolean? = true
-    val q = capture.select {
+    val q = sql.select {
       val e = from(Table<Person>())
       where { param(nullableBool)?.let { if (param(false)) param(false) else param(true) } ?: false }
       e.firstName
@@ -85,7 +78,7 @@ class BooleanLiteralSpec : FreeSpec({
 
   "exists - lifted complex - notnull->true->true" {
     val nullableBool: Boolean? = true
-    val q = capture.select {
+    val q = sql.select {
       val e = from(Table<Person>())
       where { param(nullableBool)?.let { if (param(true)) param(true) else param(false) } ?: false }
       e.firstName
@@ -95,7 +88,7 @@ class BooleanLiteralSpec : FreeSpec({
 
   "exists - lifted complex - notnull->true->false" {
     val nullableBool: Boolean? = true
-    val q = capture.select {
+    val q = sql.select {
       val e = from(Table<Person>())
       where { param(nullableBool)?.let { if (param(true)) param(false) else param(true) } ?: false }
       e.firstName
@@ -105,7 +98,7 @@ class BooleanLiteralSpec : FreeSpec({
 
   "exists - lifted complex - null->true" {
     val nullableBool: Boolean? = null
-    val q = capture.select {
+    val q = sql.select {
       val e = from(Table<Person>())
       where { param(nullableBool)?.let { if (param(false)) param(false) else param(false) } ?: true }
       e.firstName
@@ -115,7 +108,7 @@ class BooleanLiteralSpec : FreeSpec({
 
   "exists - lifted complex - null->false" {
     val nullableBool: Boolean? = null
-    val q = capture.select {
+    val q = sql.select {
       val e = from(Table<Person>())
       where { param(nullableBool)?.let { if (param(true)) param(true) else param(true) } ?: false }
       e.firstName

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlserver/CastingSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/sqlserver/CastingSpec.kt
@@ -1,8 +1,7 @@
 package io.exoquery.sqlserver
 
-import io.exoquery.SqlQuery
 import io.exoquery.TestDatabases
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.runOn
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
@@ -11,32 +10,32 @@ class CastingSpec : FreeSpec({
   val ctx = TestDatabases.sqlServer
 
   "Int to String" {
-    val q = capture.select { 1.toString() }
+    val q = sql.select { 1.toString() }
     q.buildFor.SqlServer().runOn(ctx).first() shouldBe "1"
   }
 
   "String to Long" {
-    val q = capture.select { "1".toLong() }
+    val q = sql.select { "1".toLong() }
     q.buildFor.SqlServer().runOn(ctx).first() shouldBe 1
   }
   "String to Int" {
-    val q = capture.select { "1".toInt() }
+    val q = sql.select { "1".toInt() }
     q.buildFor.SqlServer().runOn(ctx).first() shouldBe 1
   }
   "String to Short" {
-    val q = capture.select { "1".toShort() }
+    val q = sql.select { "1".toShort() }
     q.buildFor.SqlServer().runOn(ctx).first() shouldBe 1
   }
   "String to Double" {
-    val q = capture.select { "1.2".toDouble() }
+    val q = sql.select { "1.2".toDouble() }
     q.buildFor.SqlServer().runOn(ctx).first() shouldBe (1.2).toDouble()
   }
   "String to Float" {
-    val q = capture.select { "1.2".toFloat() }
+    val q = sql.select { "1.2".toFloat() }
     q.buildFor.SqlServer().runOn(ctx).first() shouldBe (1.2).toFloat()
   }
   "String to Boolean" {
-    val q = capture.select { "true".toBoolean() }
+    val q = sql.select { "true".toBoolean() }
     q.buildFor.SqlServer().runOn(ctx).first() shouldBe true
   }
 })

--- a/exoquery-runner-native/src/commonMain/kotlin/io/exoquery/native/MessagesNative.kt
+++ b/exoquery-runner-native/src/commonMain/kotlin/io/exoquery/native/MessagesNative.kt
@@ -7,10 +7,10 @@ val SqliteNativeCantReturningKeysIfNotInsert =
 In Sqlite Native returningKeys can only be used for inserts. If you want to return a value from a query use the `returning` method to define a proper SQL RETURNING Clause.
 
 For example, instead of this:
-val query = capture { update<Person> { set(firstName to "Joe") } }.where { lastName == "Bloggs" }.returningKeys { id }
+val query = sql { update<Person> { set(firstName to "Joe") } }.where { lastName == "Bloggs" }.returningKeys { id }
 
 You can do this:
-val query = capture { update<Person> { set(firstName to "Joe") } }.where { lastName == "Bloggs" }.returning { id }
+val query = sql { update<Person> { set(firstName to "Joe") } }.where { lastName == "Bloggs" }.returning { id }
 
 This will become:
 UPDATE Person SET firstName = ? WHERE lastName = ? RETURNING id

--- a/exoquery-runner-native/src/commonTest/kotlin/io/exoquery/native/ActionSpec.kt
+++ b/exoquery-runner-native/src/commonTest/kotlin/io/exoquery/native/ActionSpec.kt
@@ -3,10 +3,9 @@ package io.exoquery.native
 import io.exoquery.IllegalSqlOperation
 import io.exoquery.testdata.Person
 import io.exoquery.SqliteDialect
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.native.NativeDatabaseController
 import io.exoquery.controller.runActions
-import io.exoquery.postgres.joe
 import io.exoquery.postgres.people
 import kotlinx.coroutines.runBlocking
 import kotlin.test.BeforeTest
@@ -50,7 +49,7 @@ class ActionSpec {
 
   @Test
   fun `insert simple`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -59,7 +58,7 @@ class ActionSpec {
 
   @Test
   fun `insert simple with params`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { set(firstName to param("Joe"), lastName to param("Bloggs"), age to param(111)) }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -68,7 +67,7 @@ class ActionSpec {
 
   @Test
   fun `insert simple with setParams`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { setParams(Person(1, "Joe", "Bloggs", 111)) }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -77,7 +76,7 @@ class ActionSpec {
 
   @Test
   fun `insert simple with setParams and exclusion`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { setParams(Person(1, "Joe", "Bloggs", 111)).excluding(id) }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -86,7 +85,7 @@ class ActionSpec {
 
   @Test
   fun `insert with returning`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id + 100 }
     }
     val build = q.build<SqliteDialect>()
@@ -97,7 +96,7 @@ class ActionSpec {
   @Test
   fun `insert with returning using param`() = runBlocking {
     val n = 1000
-    val q = capture {
+    val q = sql {
       insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id + 100 + param(n) }
     }
     val build = q.build<SqliteDialect>()
@@ -107,7 +106,7 @@ class ActionSpec {
 
   @Test
   fun `insert with returning - multiple`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returning { p -> p.id to p.firstName }
     }
     val build = q.build<SqliteDialect>()
@@ -117,7 +116,7 @@ class ActionSpec {
 
   @Test
   fun `insert with returning keys`() = runBlocking {
-    val q = capture {
+    val q = sql {
       insert<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.returningKeys { id }
     }
     val build = q.build<SqliteDialect>()
@@ -128,7 +127,7 @@ class ActionSpec {
   @Test
   fun `update simple`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -138,7 +137,7 @@ class ActionSpec {
   @Test
   fun `update no condition`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       update<Person> { set(firstName to param("Joe"), lastName to param("Bloggs"), age to 111) }.all()
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 2
@@ -152,7 +151,7 @@ class ActionSpec {
   fun `update with setParams`() = runBlocking {
     ctx.insertGeorgeAndJim()
     val updateCall = Person(1, "Joe", "Bloggs", 111)
-    val q = capture {
+    val q = sql {
       // TODO need to make a warning when this situation happens, can't have param instances here
       // update<Person> { setParams(Person(1, param("Joe"), param("Bloggs"), 111)) }.filter { p -> p.id == 1 }
       update<Person> { setParams(updateCall) }.filter { p -> p.id == 1 }
@@ -166,7 +165,7 @@ class ActionSpec {
     ctx.insertGeorgeAndJim()
     // Set a large Id that should specifically be excluded from insertion
     val updateCall = Person(1000, "Joe", "Bloggs", 111)
-    val q = capture {
+    val q = sql {
       // Set the ID to 0 so we can be sure
       update<Person> { setParams(updateCall).excluding(id) }.filter { p -> p.id == 1 }
     }
@@ -177,7 +176,7 @@ class ActionSpec {
   @Test
   fun `update with returning`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returning { p -> p.id + 100 }
     }
     val build = q.build<SqliteDialect>()
@@ -188,7 +187,7 @@ class ActionSpec {
   @Test
   fun `update with returning - multiple`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returning { p -> p.id to p.firstName }
     }
     val build = q.build<SqliteDialect>()
@@ -198,7 +197,7 @@ class ActionSpec {
 
   @Test
   fun `update with returningKeys`() = runBlocking {
-    val q = capture {
+    val q = sql {
       update<Person> { set(firstName to "Joe", lastName to "Bloggs", age to 111) }.filter { p -> p.id == 1 }.returningKeys { id }
     }
     val build = q.build<SqliteDialect>()
@@ -211,7 +210,7 @@ class ActionSpec {
   @Test
   fun `delete simple`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       delete<Person>().filter { p -> p.id == 1 }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 1
@@ -221,7 +220,7 @@ class ActionSpec {
   @Test
   fun `delete no condition`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       delete<Person>().all()
     }
     q.build<SqliteDialect>().runOn(ctx) shouldBe 2
@@ -231,7 +230,7 @@ class ActionSpec {
   @Test
   fun `delete with returning`() = runBlocking {
     ctx.insertGeorgeAndJim()
-    val q = capture {
+    val q = sql {
       delete<Person>().filter { p -> p.id == 1 }.returning { p -> p.id + 100 }
     }
     val build = q.build<SqliteDialect>()
@@ -241,7 +240,7 @@ class ActionSpec {
 
   @Test
   fun `delete with returningKeys`() = runBlocking {
-    val q = capture {
+    val q = sql {
       delete<Person>().filter { p -> p.id == 1 }.returningKeys { id }
     }
     val build = q.build<SqliteDialect>()

--- a/exoquery-runner-native/src/commonTest/kotlin/io/exoquery/native/QuerySpec.kt
+++ b/exoquery-runner-native/src/commonTest/kotlin/io/exoquery/native/QuerySpec.kt
@@ -5,7 +5,7 @@ import io.exoquery.Ord
 import io.exoquery.testdata.Person
 import io.exoquery.SqliteDialect
 import io.exoquery.testdata.Robot
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
@@ -39,7 +39,7 @@ class QuerySpec {
 
   @Test
   fun `simple`() = runBlocking {
-    val q = capture { Table<Person>() }
+    val q = sql { Table<Person>() }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222),
@@ -49,7 +49,7 @@ class QuerySpec {
 
   @Test
   fun `filter`() = runBlocking {
-    val q = capture { Table<Person>().filter { it.firstName == "Joe" } }
+    val q = sql { Table<Person>().filter { it.firstName == "Joe" } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -59,7 +59,7 @@ class QuerySpec {
   @Test
   fun `filter with param`() = runBlocking {
     val joe = "Joe"
-    val q = capture { Table<Person>().filter { it.firstName == param(joe) } }
+    val q = sql { Table<Person>().filter { it.firstName == param(joe) } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -68,7 +68,7 @@ class QuerySpec {
 
   @Test
   fun `where`() = runBlocking {
-    val q = capture { Table<Person>().where { firstName == "Joe" } }
+    val q = sql { Table<Person>().where { firstName == "Joe" } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -77,7 +77,7 @@ class QuerySpec {
 
   @Test
   fun `filter + sortedBy`() = runBlocking {
-    val q = capture { Table<Person>().filter { it.firstName == "Joe" }.sortedBy { it.age } }
+    val q = sql { Table<Person>().filter { it.firstName == "Joe" }.sortedBy { it.age } }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -86,7 +86,7 @@ class QuerySpec {
 
   @Test
   fun `filter + correlated isNotEmpty`() = runBlocking {
-    val q = capture { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isNotEmpty() } }
+    val q = sql { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isNotEmpty() } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -95,7 +95,7 @@ class QuerySpec {
 
   @Test
   fun `filter + correlated isEmpty`() = runBlocking {
-    val q = capture { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isEmpty() } }
+    val q = sql { Table<Person>().filter { p -> Table<Address>().filter { it.ownerId == p.id }.isEmpty() } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(3, "Jim", "Roogs", 333)
     )
@@ -103,7 +103,7 @@ class QuerySpec {
 
   @Test
   fun `sort + take`() = runBlocking {
-    val q = capture { Table<Person>().sortedBy { it.age }.take(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.take(1) }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(1, "Joe", "Bloggs", 111)
     )
@@ -111,7 +111,7 @@ class QuerySpec {
 
   @Test
   fun `sort + drop`() = runBlocking {
-    val q = capture { Table<Person>().sortedBy { it.age }.drop(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.drop(1) }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(2, "Joe", "Doggs", 222),
       Person(3, "Jim", "Roogs", 333)
@@ -120,7 +120,7 @@ class QuerySpec {
 
   @Test
   fun `distinct`() = runBlocking {
-    val q = capture { Table<Person>().map { it.firstName }.distinct() }
+    val q = sql { Table<Person>().map { it.firstName }.distinct() }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       "Joe",
       "Jim"
@@ -130,7 +130,7 @@ class QuerySpec {
   // Not supported in Sqlite
   //@Test
   //fun `distinctOn`() = runBlocking {
-  //  val q = capture { Table<Person>().distinctOn { it.firstName } }
+  //  val q = sql { Table<Person>().distinctOn { it.firstName } }
   //  q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
   //    Person(1, "Joe", "Bloggs", 111),
   //    Person(3, "Jim", "Roogs", 333)
@@ -139,7 +139,7 @@ class QuerySpec {
 
   @Test
   fun `sort + drop + take`() = runBlocking {
-    val q = capture { Table<Person>().sortedBy { it.age }.drop(1).take(1) }
+    val q = sql { Table<Person>().sortedBy { it.age }.drop(1).take(1) }
     q.build<SqliteDialect>().runOn(ctx) shouldBe listOf(
       Person(2, "Joe", "Doggs", 222)
     )
@@ -147,7 +147,7 @@ class QuerySpec {
 
   @Test
   fun `map`() = runBlocking {
-    val q = capture { Table<Person>().map { it.firstName to it.lastName } }
+    val q = sql { Table<Person>().map { it.firstName to it.lastName } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       "Joe" to "Bloggs",
       "Joe" to "Doggs",
@@ -163,7 +163,7 @@ class QuerySpec {
 
   @Test
   fun `map to custom`() = runBlocking {
-    val q = capture { Table<Person>().map { CustomPerson(Name(it.firstName, it.lastName), it.age) } }
+    val q = sql { Table<Person>().map { CustomPerson(Name(it.firstName, it.lastName), it.age) } }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       CustomPerson(Name("Joe", "Bloggs"), 111),
       CustomPerson(Name("Joe", "Doggs"), 222),
@@ -173,7 +173,7 @@ class QuerySpec {
 
   @Test
   fun `nested`() = runBlocking {
-    val q = capture { Table<Person>().nested() }
+    val q = sql { Table<Person>().nested() }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222),
@@ -183,9 +183,9 @@ class QuerySpec {
 
   @Test
   fun `union`() = runBlocking {
-    val bloggs = capture { Table<Person>().filter { it.lastName == "Bloggs" } }
-    val doggs = capture { Table<Person>().filter { it.lastName == "Doggs" } }
-    val q = capture { bloggs union doggs }
+    val bloggs = sql { Table<Person>().filter { it.lastName == "Bloggs" } }
+    val doggs = sql { Table<Person>().filter { it.lastName == "Doggs" } }
+    val q = sql { bloggs union doggs }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
       Person(1, "Joe", "Bloggs", 111),
       Person(2, "Joe", "Doggs", 222)
@@ -195,11 +195,11 @@ class QuerySpec {
   // TODO probably only need to test for one DB e.g. postgres, move it out
   @Test
   fun `deconstruct columns - from a table`() = runBlocking {
-    val names = capture.select {
+    val names = sql.select {
       val p = from(Table<Person>())
       p.firstName to p.lastName
     }
-    val q = capture.select {
+    val q = sql.select {
       val (first, last) = from(names)
       first + " - " + last
     }
@@ -212,11 +212,11 @@ class QuerySpec {
 
   @Test
   fun `deconstruct columns - from a table - mapped`() = runBlocking {
-    val names = capture.select {
+    val names = sql.select {
       val p = from(Table<Person>())
       p.firstName to p.lastName
     }
-    val q = capture {
+    val q = sql {
       names.map { (first, last) -> first + " - " + last }
     }
     q.build<SqliteDialect>().runOn(ctx) shouldContainExactlyInAnyOrder listOf(
@@ -229,13 +229,13 @@ class QuerySpec {
   @Test
   fun `deconstruct join - from a join`() = runBlocking {
     val join =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>())
         val a = join(Table<Address>()) { a -> a.ownerId == p.id }
         p to a
       }
     val deconstuct =
-      capture.select {
+      sql.select {
         val (p, a) = from(join)
         val r = join(Table<Robot>()) { r -> r.ownerId == p.id }
         Triple(p, a, r)
@@ -252,7 +252,7 @@ class QuerySpec {
 
   @Test
   fun `joins_Person_Address_join`() = runBlocking {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       val a = join(Table<Address>()) { a -> a.ownerId == p.id }
       p to a
@@ -266,7 +266,7 @@ class QuerySpec {
 
   @Test
   fun `joins_Person_Address_left_join`() = runBlocking {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
       p to a
@@ -281,7 +281,7 @@ class QuerySpec {
 
   @Test
   fun `joins_Person_Address_left_join_plus_groupBy_name`() = runBlocking {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
       groupBy(p.firstName)
@@ -295,7 +295,7 @@ class QuerySpec {
 
   @Test
   fun `joins_Person_Address_left_join_plus_groupBy_name_plus_filter`() = runBlocking {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
       where { p.lastName == "Doggs" || p.lastName == "Roogs" }
@@ -310,7 +310,7 @@ class QuerySpec {
 
   @Test
   fun `joins_Person_address_left_join_plus_groupBy_name_plus_filter_plus_orderBy`() = runBlocking {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
       where { p.lastName == "Doggs" || p.lastName == "Roogs" }

--- a/exoquery-runner-native/src/commonTest/kotlin/io/exoquery/native/TestData.kt
+++ b/exoquery-runner-native/src/commonTest/kotlin/io/exoquery/native/TestData.kt
@@ -2,20 +2,20 @@ package io.exoquery.postgres
 
 import io.exoquery.testdata.Person
 import io.exoquery.SqliteDialect
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.controller.native.NativeDatabaseController
 import io.exoquery.native.runOn
 
-suspend fun NativeDatabaseController.people() = capture { Table<Person>() }.build<SqliteDialect>().runOn(this)
+suspend fun NativeDatabaseController.people() = sql { Table<Person>() }.build<SqliteDialect>().runOn(this)
 
 suspend fun NativeDatabaseController.insertPerson(person: Person) =
-  capture { insert<Person> { setParams(person) } }.build<SqliteDialect>().runOn(this)
+  sql { insert<Person> { setParams(person) } }.build<SqliteDialect>().runOn(this)
 
 suspend fun NativeDatabaseController.insertPeople() =
-  people.forEach { capture { insert<Person> { setParams(it) } }.build<SqliteDialect>().runOn(this) }
+  people.forEach { sql { insert<Person> { setParams(it) } }.build<SqliteDialect>().runOn(this) }
 
 suspend fun NativeDatabaseController.insertAllPeople() =
-  allPeople.forEach { capture { insert<Person> { setParams(it) } }.build<SqliteDialect>().runOn(this) }
+  allPeople.forEach { sql { insert<Person> { setParams(it) } }.build<SqliteDialect>().runOn(this) }
 
 val joe = Person(1, "Joe", "Bloggs", 111)
 val joe2 = Person(2, "Joe", "Doggs", 222)

--- a/exoquery-runner-native/src/commonTest/kotlin/io/exoquery/native/TransactionSpec.kt
+++ b/exoquery-runner-native/src/commonTest/kotlin/io/exoquery/native/TransactionSpec.kt
@@ -1,11 +1,10 @@
 package io.exoquery.native
 
 import io.exoquery.testdata.Person
-import io.exoquery.capture
-import io.exoquery.capture.invoke
+import io.exoquery.sql
 import io.exoquery.controller.runActions
 import io.exoquery.controller.transaction
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
@@ -26,12 +25,12 @@ class TransactionSpec : FreeSpec({
   val jack = Person(2, "Jack", "Roogs", 222)
 
   suspend fun select() =
-    capture { Table<Person>() }.build<PostgresDialect>().runOn(ctx)
+    sql { Table<Person>() }.build<PostgresDialect>().runOn(ctx)
 
   "transaction support" - {
     "success" {
       ctx.transaction {
-        capture {
+        sql {
           insert<Person> { setParams(joe) }
         }.build<PostgresDialect>().runOnTransaction()
       }
@@ -40,12 +39,12 @@ class TransactionSpec : FreeSpec({
 
     "failure" {
       // Insert joe record
-      capture { insert<Person> { setParams(joe) } }.build<PostgresDialect>().runOn(ctx)
+      sql { insert<Person> { setParams(joe) } }.build<PostgresDialect>().runOn(ctx)
 
 
       shouldThrow<IllegalStateException> {
         ctx.transaction {
-          capture {
+          sql {
             insert<Person> { setParams(jack) }
           }.build<PostgresDialect>().runOnTransaction()
           throw IllegalStateException()
@@ -55,7 +54,7 @@ class TransactionSpec : FreeSpec({
     }
 
     "nested" {
-      val cap = capture {
+      val cap = sql {
         insert<Person> { setParams(joe) }
       }.build<PostgresDialect>()
 

--- a/scripts/Dockerfile-setup
+++ b/scripts/Dockerfile-setup
@@ -4,6 +4,7 @@ MAINTAINER gustavo.amigo@gmail.com
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    gnupg \
     mariadb-client \
     netcat \
     postgresql-client \
@@ -18,10 +19,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 ADD https://repo1.maven.org/maven2/sqlline/sqlline/1.12.0/sqlline-1.12.0-jar-with-dependencies.jar /sqlline/sqlline.jar
 ADD https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc8/19.3.0.0/ojdbc8-19.3.0.0.jar /sqlline/ojdbc.jar
 
-RUN curl https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc && \
-    curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
-    apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools
+RUN curl --retry 5 --retry-delay 5 --connect-timeout 20 https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc && \
+    curl --retry 5 --retry-delay 5 --connect-timeout 20 https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get -o Acquire::https::packages.microsoft.com::Verify-Peer="false" -o Acquire::https::Timeout=20 -o Acquire::http::Timeout=20 update && \
+    ACCEPT_EULA=Y apt-get -o Acquire::https::Timeout=20 -o Acquire::http::Timeout=20 install -y msodbcsql18 mssql-tools
 
 ENV PATH $PATH:/opt/mssql-tools/bin
 

--- a/testing/src/commonMain/kotlin/io/exoquery/AcrossFiles1.kt
+++ b/testing/src/commonMain/kotlin/io/exoquery/AcrossFiles1.kt
@@ -1,25 +1,24 @@
 package io.exoquery
 
-import io.exoquery.annotation.CapturedDynamic
 import io.exoquery.annotation.CapturedFunction
 
 data class PersonCrs(val id: Int, val name: String)
 data class AddressCrs(val ownerId: Int, val street: String)
 
 
-inline fun crossFileSelect() = capture.select {
+inline fun crossFileSelect() = sql.select {
   val p = from(Table<PersonCrs>())
   val a = join(Table<AddressCrs>()) { it.ownerId == p.id }
   p to a
 }
 
 inline fun crossFileExpr() =
-  capture {
+  sql {
     Table<PersonCrs>().filter { it.name == "JohnExpr"  }
   }
 
 inline fun crossFileAction() =
-  capture {
+  sql {
     insert<PersonCrs> { set(name to "JohnActionA") }
   }
 
@@ -28,19 +27,19 @@ inline fun crossFileAction() =
 val batchInserts = listOf(PersonCrs(1, "JohnBatchA")).asSequence()
 
 inline fun crossFileBatchAction(batchInserts: Sequence<PersonCrs>) =
-  capture.batch(batchInserts) {
+  sql.batch(batchInserts) {
     insert<PersonCrs> { set(name to "JohnActionA") }
   }
 
 @CapturedFunction
 inline fun crossFileCapSelect(q: SqlQuery<PersonCrs>) =
-  // TODO what happens if it's a capture.select here?
-  capture {
+  // TODO what happens if it's a sql.select here?
+  sql {
     q.filter { p -> p.name == "JohnA" }
   }
 
 //@CapturedDynamic
 //inline fun crossFileDynSelect(q: SqlQuery<PersonCrs>) =
-//  capture {
+//  sql {
 //    q.filter { p -> p.name == "JohnA" }
 //  }

--- a/testing/src/commonMain/kotlin/io/exoquery/AcrossFiles2.kt
+++ b/testing/src/commonMain/kotlin/io/exoquery/AcrossFiles2.kt
@@ -1,14 +1,13 @@
 package io.exoquery
 
-import io.exoquery.annotation.CapturedDynamic
 import io.exoquery.annotation.CapturedFunction
 
 
-inline fun crossFileSelectExpr() = capture {
+inline fun crossFileSelectExpr() = sql {
   crossFileSelect().filter { pair ->  pair.first.id > 1 }
 }
 
-inline fun crossFileSelectSelect () = capture.select {
+inline fun crossFileSelectSelect () = sql.select {
   // TODO fails when .nested() is removed. Need to look into why
   val p = from(crossFileSelect().nested())
   val a = join(Table<AddressCrs>()) { it.ownerId == p.first.id }
@@ -16,26 +15,26 @@ inline fun crossFileSelectSelect () = capture.select {
 }
 
 @CapturedFunction
-inline fun crossFileCapSelectCapExpr(q: SqlQuery<PersonCrs>) = capture {
+inline fun crossFileCapSelectCapExpr(q: SqlQuery<PersonCrs>) = sql {
   crossFileCapSelect(Table<PersonCrs>().filter { p -> p.name == "JohnB" })
 }
 
 @CapturedFunction
-inline fun crossFileCapSelectCapSelect(q: SqlQuery<PersonCrs>) = capture.select {
+inline fun crossFileCapSelectCapSelect(q: SqlQuery<PersonCrs>) = sql.select {
   val p = from(crossFileCapSelect(q))
   val a = join(Table<AddressCrs>()) { it.ownerId == p.id }
   p to a
 }
 
 //@CapturedDynamic
-//inline fun crossFileDynSelectDynSelect(q: SqlQuery<PersonCrs>) = capture.select {
+//inline fun crossFileDynSelectDynSelect(q: SqlQuery<PersonCrs>) = sql.select {
 //  val p = from(crossFileDynSelect(q))
 //  val a = join(Table<AddressCrs>()) { it.ownerId == p.id }
 //  p to a
 //}
 
 inline fun crossFileExprExpr() =
-  capture {
+  sql {
     crossFileExpr().filter { it.name == "JohnExprExpr"  }
   }
 

--- a/testing/src/commonTest/kotlin/io/exoquery/ActionOnConflictReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ActionOnConflictReq.kt
@@ -1,11 +1,11 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Person
 
 class ActionOnConflictReq: GoldenSpecDynamic(ActionOnConflictReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "onConflictUpdate" {
-    val q = capture {
+    val q = sql {
       insert<Person> {
         set(name to "Joe", age to 123).onConflictUpdate(id) { excluding -> set(name to excluding.name, age to excluding.age) }
       }
@@ -15,7 +15,7 @@ class ActionOnConflictReq: GoldenSpecDynamic(ActionOnConflictReqGoldenDynamic, M
   }
 
   "onConflictUpdate - complex" {
-    val q = capture {
+    val q = sql {
       insert<Person> {
         set(name to "Joe", age to 123).onConflictUpdate(id) { excluding -> set(name to name + excluding.name, age to age + excluding.age) }
       }
@@ -25,7 +25,7 @@ class ActionOnConflictReq: GoldenSpecDynamic(ActionOnConflictReqGoldenDynamic, M
   }
 
   "onConflictUpdate - complex + returning" {
-    val q = capture {
+    val q = sql {
       insert<Person> {
         set(name to "Joe", age to 123).onConflictUpdate(id) { excluding -> set(name to name + excluding.name, age to age + excluding.age) }
       }.returning { p -> p.id }
@@ -35,7 +35,7 @@ class ActionOnConflictReq: GoldenSpecDynamic(ActionOnConflictReqGoldenDynamic, M
   }
 
   "onConflictUpdate - multiple" {
-    val q = capture {
+    val q = sql {
       insert<Person> {
         // Technically invalid SQL but we want to test the parsing
         set(name to "Joe", age to 123).onConflictUpdate(id, name) { excluding -> set(name to excluding.name, age to excluding.age) }
@@ -47,7 +47,7 @@ class ActionOnConflictReq: GoldenSpecDynamic(ActionOnConflictReqGoldenDynamic, M
 
   "onConflictUpdate - setParams" {
     val joe = Person(1, "Joe", 123)
-    val q = capture {
+    val q = sql {
       insert<Person> {
         setParams(joe).onConflictUpdate(id) { excluding -> set(name to excluding.name, age to excluding.age) }
       }
@@ -58,7 +58,7 @@ class ActionOnConflictReq: GoldenSpecDynamic(ActionOnConflictReqGoldenDynamic, M
 
   "onConflictUpdate - setParams + exclusion" {
     val joe = Person(1, "Joe", 123)
-    val q = capture {
+    val q = sql {
       insert<Person> {
         setParams(joe).excluding(id).onConflictUpdate(id) { excluding -> set(name to excluding.name, age to excluding.age) }
       }
@@ -68,7 +68,7 @@ class ActionOnConflictReq: GoldenSpecDynamic(ActionOnConflictReqGoldenDynamic, M
   }
 
   "onConflictIgnore" {
-    val q = capture {
+    val q = sql {
       insert<Person> {
         set(name to "Joe", age to 123).onConflictIgnore(id)
       }
@@ -78,7 +78,7 @@ class ActionOnConflictReq: GoldenSpecDynamic(ActionOnConflictReqGoldenDynamic, M
   }
 
   "onConflictIgnore - multiple" {
-    val q = capture {
+    val q = sql {
       insert<Person> {
         set(name to "Joe", age to 123).onConflictIgnore(id, name)
       }
@@ -89,7 +89,7 @@ class ActionOnConflictReq: GoldenSpecDynamic(ActionOnConflictReqGoldenDynamic, M
 
   "onConflictIgnore - multiple - setParams" {
     val joe = Person(1, "Joe", 123)
-    val q = capture {
+    val q = sql {
       insert<Person> {
         setParams(joe).onConflictIgnore(id, name)
       }
@@ -100,7 +100,7 @@ class ActionOnConflictReq: GoldenSpecDynamic(ActionOnConflictReqGoldenDynamic, M
 
   "onConflictIgnore - setParams + exclusion" {
     val joe = Person(1, "Joe", 123)
-    val q = capture {
+    val q = sql {
       insert<Person> {
         setParams(joe).excluding(id).onConflictIgnore(id, name)
       }

--- a/testing/src/commonTest/kotlin/io/exoquery/ActionReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ActionReq.kt
@@ -1,34 +1,34 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Person
 import io.exoquery.testdata.PersonNullable
 
 class ActionReq: GoldenSpecDynamic(ActionReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "insert" - {
     "simple" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to "Joe", age to 123) }
       }
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "simple - nullable" {
-      val q = capture {
+      val q = sql {
         insert<PersonNullable> { set(name to "Joe", age to 123) }
       }
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "simple with params" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to param("Joe"), age to param(123)) }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "simple with params - nullable" {
-      val q = capture {
+      val q = sql {
         insert<PersonNullable> { set(name to param("Joe"), age to param(123)) }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
@@ -36,49 +36,49 @@ class ActionReq: GoldenSpecDynamic(ActionReqGoldenDynamic, Mode.ExoGoldenTest(),
     }
     "simple with params - nullable - actual null" {
       val v: String? = null
-      val q = capture {
+      val q = sql {
         insert<PersonNullable> { set(name to param(v), age to param(123)) }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "simple with setParams" {
-      val q = capture {
+      val q = sql {
         insert<Person> { setParams(Person(1, "Joe", 123)) }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "simple with setParams - nullable" {
-      val q = capture {
+      val q = sql {
         insert<PersonNullable> { setParams(PersonNullable(1, "Joe", 123)) }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "simple with setParams - nullable - actual null" {
-      val q = capture {
+      val q = sql {
         insert<PersonNullable> { setParams(PersonNullable(1, null, 123)) }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "simple with setParams and exclusion" {
-      val q = capture {
+      val q = sql {
         insert<Person> { setParams(Person(1, "Joe", 123)).excluding(id) }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "simple with setParams and exclusion - multiple" {
-      val q = capture {
+      val q = sql {
         insert<Person> { setParams(Person(1, "Joe", 123)).excluding(id, name) }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "with returning" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to "Joe", age to 123) }.returning { p -> p.id }
       }
       val build = q.build<PostgresDialect>()
@@ -88,7 +88,7 @@ class ActionReq: GoldenSpecDynamic(ActionReqGoldenDynamic, Mode.ExoGoldenTest(),
       shouldBeGolden(build.actionReturningKind.toString(), "returningType")
     }
     "with returning - multiple" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to "Joe", age to 123) }.returning { p -> p.id to p.name }
       }
       val build = q.build<PostgresDialect>()
@@ -99,7 +99,7 @@ class ActionReq: GoldenSpecDynamic(ActionReqGoldenDynamic, Mode.ExoGoldenTest(),
     }
     "with returning params" {
       val myParam = "myParamValue"
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to param("Joe"), age to param(123)) }.returning { p -> p.name to param(myParam) }
       }.determinizeDynamics()
       val build = q.build<PostgresDialect>()
@@ -109,7 +109,7 @@ class ActionReq: GoldenSpecDynamic(ActionReqGoldenDynamic, Mode.ExoGoldenTest(),
       shouldBeGolden(build.actionReturningKind.toString(), "returningType")
     }
     "with returningKeys" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to "Joe", age to 123) }.returningKeys { id }
       }
       val build = q.build<PostgresDialect>()
@@ -118,7 +118,7 @@ class ActionReq: GoldenSpecDynamic(ActionReqGoldenDynamic, Mode.ExoGoldenTest(),
       shouldBeGolden(build.actionReturningKind.toString(), "returningType")
     }
     "with returningKeys - multiple" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to "Joe", age to 123) }.returningKeys { id to name }
       }
       val build = q.build<PostgresDialect>()
@@ -130,35 +130,35 @@ class ActionReq: GoldenSpecDynamic(ActionReqGoldenDynamic, Mode.ExoGoldenTest(),
 
   "update" - {
     "simple" {
-      val q = capture {
+      val q = sql {
         update<Person> { set(name to "Joe", age to 123) }.filter { p -> p.id == 1 }
       }
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "no condition" {
-      val q = capture {
+      val q = sql {
         update<Person> { set(name to "Joe", age to 123) }.all()
       }
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "with setParams" {
-      val q = capture {
+      val q = sql {
         update<Person> { setParams(Person(1, "Joe", 123)) }.filter { p -> p.id == 1 }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "with setParams and exclusion" {
-      val q = capture {
+      val q = sql {
         update<Person> { setParams(Person(1, "Joe", 123)).excluding(id) }.filter { p -> p.id == 1 }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "with returning" {
-      val q = capture {
+      val q = sql {
         update<Person> { set(name to "Joe", age to 123) }.filter { p -> p.id == 1 }.returning { p -> p.id }
       }
       val build = q.build<PostgresDialect>()
@@ -168,7 +168,7 @@ class ActionReq: GoldenSpecDynamic(ActionReqGoldenDynamic, Mode.ExoGoldenTest(),
       shouldBeGolden(build.actionReturningKind.toString(), "returningType")
     }
     "with returningKeys" {
-      val q = capture {
+      val q = sql {
         update<Person> { set(name to "Joe", age to 123) }.filter { p -> p.id == 1 }.returningKeys { id }
       }
       val build = q.build<PostgresDialect>()
@@ -180,21 +180,21 @@ class ActionReq: GoldenSpecDynamic(ActionReqGoldenDynamic, Mode.ExoGoldenTest(),
 
   "delete" - {
     "simple" {
-      val q = capture {
+      val q = sql {
         delete<Person>().filter { p -> p.id == 1 }
       }
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "no condition" {
-      val q = capture {
+      val q = sql {
         delete<Person>().all()
       }
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "with returning" {
-      val q = capture {
+      val q = sql {
         delete<Person>().filter { p -> p.id == 1 }.returning { p -> p.id }
       }
       val build = q.build<PostgresDialect>()
@@ -203,7 +203,7 @@ class ActionReq: GoldenSpecDynamic(ActionReqGoldenDynamic, Mode.ExoGoldenTest(),
       shouldBeGolden(build.actionReturningKind.toString(), "returningType")
     }
     "with returningKeys" {
-      val q = capture {
+      val q = sql {
         delete<Person>().filter { p -> p.id == 1 }.returningKeys { id }
       }
       val build = q.build<PostgresDialect>()

--- a/testing/src/commonTest/kotlin/io/exoquery/AggregateReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/AggregateReq.kt
@@ -1,13 +1,13 @@
 package io.exoquery
 
 import io.exoquery.testdata.Person
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 class AggregateReq: GoldenSpecDynamic(AggregateReqGoldenDynamic, Mode.ExoGoldenTest(), {
 
   "value function aggregate" - {
     "avg" {
-      val avgAge = capture.select {
+      val avgAge = sql.select {
         Table<Person>().map { it.age }.avg()
       }
       shouldBeGolden(avgAge.xr, "XR")
@@ -15,7 +15,7 @@ class AggregateReq: GoldenSpecDynamic(AggregateReqGoldenDynamic, Mode.ExoGoldenT
     }
 
     "avg typed" {
-      val avgAge = capture.select {
+      val avgAge = sql.select {
         Table<Person>().map { it.age }.avg<Int>()
       }
       shouldBeGolden(avgAge.xr, "XR")
@@ -23,7 +23,7 @@ class AggregateReq: GoldenSpecDynamic(AggregateReqGoldenDynamic, Mode.ExoGoldenT
     }
 
     "stdev" {
-      val stddevAge = capture.select {
+      val stddevAge = sql.select {
         Table<Person>().map { it.age }.stddev()
       }
       shouldBeGolden(stddevAge.xr, "XR")
@@ -31,7 +31,7 @@ class AggregateReq: GoldenSpecDynamic(AggregateReqGoldenDynamic, Mode.ExoGoldenT
     }
 
     "stdev typed" {
-      val stddevAge = capture.select {
+      val stddevAge = sql.select {
         Table<Person>().map { it.age }.stddev<Int>()
       }
       shouldBeGolden(stddevAge.xr, "XR")
@@ -41,7 +41,7 @@ class AggregateReq: GoldenSpecDynamic(AggregateReqGoldenDynamic, Mode.ExoGoldenT
 
   "column function aggregate" - {
     "avg" {
-      val avgAge = capture.select {
+      val avgAge = sql.select {
         Table<Person>().map { avg(it.age) }.value()
       }
       shouldBeGolden(avgAge.xr, "XR")
@@ -49,7 +49,7 @@ class AggregateReq: GoldenSpecDynamic(AggregateReqGoldenDynamic, Mode.ExoGoldenT
     }
 
     "avg typed" {
-      val avgAge = capture.select {
+      val avgAge = sql.select {
         Table<Person>().map { avg<Int>(it.age) }.value()
       }
       shouldBeGolden(avgAge.xr, "XR")
@@ -57,7 +57,7 @@ class AggregateReq: GoldenSpecDynamic(AggregateReqGoldenDynamic, Mode.ExoGoldenT
     }
 
     "stdev" {
-      val stddevAge = capture.select {
+      val stddevAge = sql.select {
         Table<Person>().map { stddev(it.age) }.value()
       }
       shouldBeGolden(stddevAge.xr, "XR")
@@ -65,7 +65,7 @@ class AggregateReq: GoldenSpecDynamic(AggregateReqGoldenDynamic, Mode.ExoGoldenT
     }
 
     "stdev typed" {
-      val stddevAge = capture.select {
+      val stddevAge = sql.select {
         Table<Person>().map { stddev<Int>(it.age) }.value()
       }
       shouldBeGolden(stddevAge.xr, "XR")

--- a/testing/src/commonTest/kotlin/io/exoquery/AtomicValueSelectSpec.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/AtomicValueSelectSpec.kt
@@ -2,7 +2,7 @@
 
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 class AtomicValueSelectSpec: GoldenSpec(AtomicValueSelectSpecGolden, {
   data class Person(val id: Int, val name: String, val age: Int)
@@ -12,9 +12,9 @@ class AtomicValueSelectSpec: GoldenSpec(AtomicValueSelectSpecGolden, {
   "parsing features spec" - {
     // apply-map takes care of the non-nested case (should have that too)
     "from(atom.nested) + join -> (p, r)" {
-      val names = capture { Table<Person>().map { p -> p.name }.nested() }
+      val names = sql { Table<Person>().map { p -> p.name }.nested() }
       val people =
-        capture.select {
+        sql.select {
           val n = from(names)
           val r = join(Table<Robot>()) { r -> n == r.model }
           n to r
@@ -22,9 +22,9 @@ class AtomicValueSelectSpec: GoldenSpec(AtomicValueSelectSpecGolden, {
       people.buildPretty<PostgresDialect>("from(atom.nested) + join -> (p, r)").shouldBeGolden()
     }
     "from(atom.nested.nested) + join -> (p, r)" {
-      val names = capture { Table<Person>().map { p -> p.name }.nested().nested() }
+      val names = sql { Table<Person>().map { p -> p.name }.nested().nested() }
       val people =
-        capture.select {
+        sql.select {
           val n = from(names)
           val r = join(Table<Robot>()) { r -> n == r.model }
           n to r
@@ -32,12 +32,12 @@ class AtomicValueSelectSpec: GoldenSpec(AtomicValueSelectSpecGolden, {
       people.buildPretty<PostgresDialect>("from(atom.nested.nested) + join -> (p, r)").shouldBeGolden()
     }
     "groupBy(n.nested) -> join(n)" {
-      val names = capture.select {
+      val names = sql.select {
         val n = from(Table<Person>().map { p -> p.name }.nested())
         groupBy(n)
         n
       }
-      val addresses = capture.select {
+      val addresses = sql.select {
         val n = from(names)
         val a = join(Table<Address>()) { a -> n == a.street }
         n to a

--- a/testing/src/commonTest/kotlin/io/exoquery/BasicQuerySanitySpec.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/BasicQuerySanitySpec.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 // Note that the 1st time you overwrite the golden file it will still fail because the compile is using teh old version
 // Also note that it won't actually override the BasicQuerySanitySpecGolden file unless you change this one
@@ -51,19 +51,19 @@ class BasicQuerySanitySpec : GoldenSpecDynamic(BasicQuerySanitySpecGoldenDynamic
 
 
   "basic query" {
-    val people = capture { Table<Person>() }
+    val people = sql { Table<Person>() }
     people.build<PostgresDialect>("basic query").shouldBeGolden()
   }
   "query with map" {
-    val people = capture { Table<Person>().map { p -> p.name } }
+    val people = sql { Table<Person>().map { p -> p.name } }
     shouldBeGolden(people.build<PostgresDialect>())
   }
   "query with filter" {
-    val people = capture { Table<Person>().filter { p -> p.age > 18 } }
+    val people = sql { Table<Person>().filter { p -> p.age > 18 } }
     shouldBeGolden(people.build<PostgresDialect>())
   }
   "query with flatMap" {
-    val people = capture { Table<Person>().flatMap { p -> Table<Address>().filter { a -> a.ownerId == p.id } } }
+    val people = sql { Table<Person>().flatMap { p -> Table<Address>().filter { a -> a.ownerId == p.id } } }
     shouldBeGolden(people.build<PostgresDialect>())
   }
 })

--- a/testing/src/commonTest/kotlin/io/exoquery/BasicSelectClauseQuotationSpec.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/BasicSelectClauseQuotationSpec.kt
@@ -4,7 +4,7 @@ package io.exoquery
 
 import io.exoquery.Ord.Asc
 import io.exoquery.Ord.Desc
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.xr.*
 import io.exoquery.xr.XR.Expression
 import io.exoquery.xr.XR.Product.Companion.TupleSmartN
@@ -31,13 +31,13 @@ class BasicSelectClauseQuotationSpec: GoldenSpec(BasicSelectClauseQuotationSpecG
   infix fun Expression.prop(propName: String): Expression = XR.Property(this, propName)
 
   "parsing features spec" - {
-    val people = capture { Table<Person>() }
+    val people = sql { Table<Person>() }
 
     data class Custom(val person: Person, val robot: Robot?)
 
     "from + join -> (p, r)" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(people)
           val r = join(Table<Robot>()) { r -> p.id == r.ownerId }
           p to r
@@ -54,7 +54,7 @@ class BasicSelectClauseQuotationSpec: GoldenSpec(BasicSelectClauseQuotationSpecG
 
     "from + join + leftJoin -> Custom(p, r)" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(people)
           val r = join(Table<Robot>()) { r -> p.id == r.ownerId }
           val a = joinLeft(Table<Address>()) { a -> p.id == a.ownerId }
@@ -76,7 +76,7 @@ class BasicSelectClauseQuotationSpec: GoldenSpec(BasicSelectClauseQuotationSpecG
 
     "from + leftJoin -> Custom(p, r)" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(people)
           val r = joinLeft(Table<Robot>()) { r -> p.id == r.ownerId }
           Custom(p, r)
@@ -93,7 +93,7 @@ class BasicSelectClauseQuotationSpec: GoldenSpec(BasicSelectClauseQuotationSpecG
 
     "from + join + where" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(people)
           val r = join(Table<Robot>()) { r -> p.id == r.ownerId }
           where { p.name == "Joe" }
@@ -111,7 +111,7 @@ class BasicSelectClauseQuotationSpec: GoldenSpec(BasicSelectClauseQuotationSpecG
     }
     "from + sort(Asc,Desc)" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(people)
           sortBy(
             p.age to Asc,
@@ -136,7 +136,7 @@ class BasicSelectClauseQuotationSpec: GoldenSpec(BasicSelectClauseQuotationSpecG
     }
     "from + sort(Asc)" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(people)
           sortBy(p.age to Asc)
           p.name
@@ -154,7 +154,7 @@ class BasicSelectClauseQuotationSpec: GoldenSpec(BasicSelectClauseQuotationSpecG
 
     "from + groupBy(a)" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(people)
           groupBy(p.age)
           p.age
@@ -173,8 +173,8 @@ class BasicSelectClauseQuotationSpec: GoldenSpec(BasicSelectClauseQuotationSpecG
 
   "from + groupBy(a, b)" {
     val people =
-      capture.select {
-        val p = from(capture { Table<Person>() })
+      sql.select {
+        val p = from(sql { Table<Person>() })
         groupBy(p.age, p.name)
         p.age
       }

--- a/testing/src/commonTest/kotlin/io/exoquery/BatchActionReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/BatchActionReq.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Person
 
 class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGoldenTest(), {
@@ -8,7 +8,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     val people = listOf(Person(1, "John", 42), Person(2, "Jane", 43), Person(3, "Jack", 44)).asSequence()
 
     "simple" {
-      val q = capture.batch(people) { p ->
+      val q = sql.batch(people) { p ->
         insert<Person> { set(name to param(p.name), age to param(p.age)) }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()
@@ -26,7 +26,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     }
 
     "simple with setParams" {
-      val q = capture.batch(people) { p ->
+      val q = sql.batch(people) { p ->
         insert<Person> { setParams(p) }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics().withNonStrictEquality()
@@ -36,7 +36,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     }
 
     "simple with setParams and exclusion" {
-      val q = capture.batch(people) { p ->
+      val q = sql.batch(people) { p ->
         insert<Person> { setParams(p).excluding(id) }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()
@@ -46,7 +46,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     }
 
     "with returning" {
-      val q = capture.batch(people) { p ->
+      val q = sql.batch(people) { p ->
         insert<Person> { set(name to param(p.name), age to param(p.age)) }.returning { p -> p.id }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()
@@ -57,7 +57,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     }
 
     "with returning and params" {
-      val q = capture.batch(people) { p ->
+      val q = sql.batch(people) { p ->
         insert<Person> { set(name to param(p.name), age to param(p.age)) }.returning { pp -> pp.id to param(p.name) }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()
@@ -68,7 +68,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     }
 
     "with returning keys" {
-      val q = capture.batch(people) { p ->
+      val q = sql.batch(people) { p ->
         insert<Person> { set(name to param(p.name), age to param(p.age)) }.returningKeys { id }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()
@@ -82,7 +82,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     val updatedPeople = listOf(Person(1, "John-A", 52), Person(2, "Jane-A", 53), Person(3, "Jack-A", 54)).asSequence()
 
     "simple" {
-      val q = capture.batch(updatedPeople) { p ->
+      val q = sql.batch(updatedPeople) { p ->
         update<Person> { set(name to param(p.name), age to param(p.age)) }.filter { pp -> pp.id == param(p.id) }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()
@@ -96,7 +96,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     }
 
     "simple - where clause" {
-      val q = capture.batch(updatedPeople) { p ->
+      val q = sql.batch(updatedPeople) { p ->
         update<Person> { set(name to param(p.name), age to param(p.age)) }.where { id == param(p.id) && age > 50 }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()
@@ -106,7 +106,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     }
 
     "simple with setParams and exclusion" {
-      val q = capture.batch(updatedPeople) { p ->
+      val q = sql.batch(updatedPeople) { p ->
         update<Person> { setParams(p).excluding(id) }.filter { pp -> pp.id == param(p.id) }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()
@@ -116,7 +116,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     }
 
     "simple with setParams and exclusion and returning param" {
-      val q = capture.batch(updatedPeople) { p ->
+      val q = sql.batch(updatedPeople) { p ->
         update<Person> { setParams(p).excluding(id) }.filter { pp -> pp.id == param(p.id) }
           .returning { pp -> pp.id to param(p.name) }
       }
@@ -130,7 +130,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
 
   "delete" - {
     "with filter - inside" {
-      val q = capture.batch(listOf(1, 2, 3).asSequence()) { id ->
+      val q = sql.batch(listOf(1, 2, 3).asSequence()) { id ->
         delete<Person>().filter { it.id == param(id) }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()
@@ -143,7 +143,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     }
     "with filter" {
       val ids = listOf(1, 2, 3).asSequence()
-      val q = capture.batch(ids) { id ->
+      val q = sql.batch(ids) { id ->
         delete<Person>().filter { p -> p.id == param(id) }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()
@@ -153,7 +153,7 @@ class BatchActionReq: GoldenSpecDynamic(BatchActionReqGoldenDynamic, Mode.ExoGol
     }
     "with returning" {
       val ids = listOf(1, 2, 3).asSequence()
-      val q = capture.batch(ids) { id ->
+      val q = sql.batch(ids) { id ->
         delete<Person>().filter { p -> p.id == param(id) }.returning { p -> p.id }
       }
       val b = q.build<PostgresDialect>().determinizeDynamics()

--- a/testing/src/commonTest/kotlin/io/exoquery/BlockStatementReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/BlockStatementReq.kt
@@ -1,12 +1,12 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Address
 import io.exoquery.testdata.Person
 
 class BlockStatementReq: GoldenSpecDynamic(BlockStatementReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "blocks with map" {
-    val p = capture {
+    val p = sql {
       Table<Person>().map {
         val name = it.name
         val age = it.age
@@ -17,7 +17,7 @@ class BlockStatementReq: GoldenSpecDynamic(BlockStatementReqGoldenDynamic, Mode.
     shouldBeGolden(p.build<PostgresDialect>(), "SQL")
   }
   "block with filter condition" {
-    val p = capture {
+    val p = sql {
       Table<Person>().filter {
         val age = it.age
         val thirty = 30
@@ -28,7 +28,7 @@ class BlockStatementReq: GoldenSpecDynamic(BlockStatementReqGoldenDynamic, Mode.
     shouldBeGolden(p.build<PostgresDialect>(), "SQL")
   }
   "block in query" {
-    val p = capture {
+    val p = sql {
       val p = Table<Person>()
       p.filter { it.age > 30 }
     }
@@ -36,7 +36,7 @@ class BlockStatementReq: GoldenSpecDynamic(BlockStatementReqGoldenDynamic, Mode.
     shouldBeGolden(p.build<PostgresDialect>(), "SQL")
   }
   "block with query clause" {
-    val p = capture {
+    val p = sql {
       val p = Table<Person>()
       select {
         val p = from(p)

--- a/testing/src/commonTest/kotlin/io/exoquery/BooleanLiteralSupportSpec.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/BooleanLiteralSupportSpec.kt
@@ -6,7 +6,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     data class Status(val name: String, val value: Boolean)
 
     "filter - simple" {
-      val q = capture {
+      val q = sql {
         Table<Ent>().filter { e -> e.b }
       }
       shouldBeGolden(q.xr, "XR")
@@ -14,7 +14,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "where - simple" {
-      val q = capture.select {
+      val q = sql.select {
         val e = from(Table<Ent>())
         where { e.b }
         e.name
@@ -24,7 +24,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "where - combined" {
-      val q = capture.select {
+      val q = sql.select {
         val e = from(Table<Ent>())
         where { e.b || e.name == "Joe" }
         e.name
@@ -34,7 +34,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "where - combined complex 1" {
-      val q = capture.select {
+      val q = sql.select {
         val e = from(Table<Ent>())
         where { e.b || e.name == "Joe" || e.bb }
         e.name
@@ -44,7 +44,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "where - combined complex 2" {
-      val q = capture.select {
+      val q = sql.select {
         val e = from(Table<Ent>())
         where { e.b || if (e.bb) e.bc || e.b else e.num > 1 }
         e.name
@@ -55,7 +55,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
 
 
     "condition" {
-      val q = capture {
+      val q = sql {
         Table<Ent>().map { e -> e.name to if (e.b == e.bb) e.bc else e.b == e.bb }
       }
       shouldBeGolden(q.xr, "XR")
@@ -63,7 +63,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "map-clause" {
-      val q = capture {
+      val q = sql {
         Table<Ent>().map { e -> e.bb == true }
       }
       shouldBeGolden(q.xr, "XR")
@@ -71,7 +71,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "map-clause with int" {
-      val q = capture {
+      val q = sql {
         Table<Ent>().map { e -> e.num > 10 }
       }
       shouldBeGolden(q.xr, "XR")
@@ -79,7 +79,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "tuple" {
-      val q = capture {
+      val q = sql {
         Table<Ent>().map { e -> "foo" to (e.bb == true) }
       }
       shouldBeGolden(q.xr, "XR")
@@ -87,7 +87,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "tuple-multi" {
-      val q = capture {
+      val q = sql {
         Table<Ent>().map { e -> (e.bb == true) to (e.bc == false) to (e.num > 1) }
       }
       shouldBeGolden(q.xr, "XR")
@@ -95,7 +95,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "case-class" {
-      val q = capture {
+      val q = sql {
         Table<Ent>().map { e -> Status("foo", e.bb == true) }
       }
       shouldBeGolden(q.xr, "XR")
@@ -181,7 +181,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
 
     "expressify asCondition" - {
       "filter-clause" {
-        val q = capture {
+        val q = sql {
           Table<Ent>().filter { e -> free("${e.i} > 123").asConditon() }
         }
         shouldBeGolden(q.xr, "XR")
@@ -189,7 +189,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
       }
 
       "pure filter-clause" {
-        val q = capture {
+        val q = sql {
           Table<Ent>().filter { e -> free("${e.i} > 123").asPureConditon() }
         }
         shouldBeGolden(q.xr, "XR")
@@ -197,7 +197,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
       }
 
       "map-clause" {
-        val q = capture {
+        val q = sql {
           Table<Ent>().map { e -> free("${e.i} > 123").asConditon() }
         }
         shouldBeGolden(q.xr, "XR")
@@ -205,7 +205,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
       }
 
       "distinct map-clause" {
-        val q = capture {
+        val q = sql {
           Table<Ent>()
             .map { e -> "foo" to free("${e.i} > 123").asConditon() }
             .distinct()
@@ -216,7 +216,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
       }
 
       "distinct tuple map-clause" {
-        val q = capture {
+        val q = sql {
           Table<Ent>()
             .map { e -> "foo" to free("${e.i} > 123").asPureConditon() }
             .distinct()
@@ -226,7 +226,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
       }
 
       "pure map-clause" {
-        val q = capture {
+        val q = sql {
           Table<Ent>().map { e -> free("${e.i} > 123").asPureConditon() }
         }
         shouldBeGolden(q.xr, "XR")
@@ -234,7 +234,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
       }
 
       "pure distinct map-clause" {
-        val q = capture {
+        val q = sql {
           Table<Ent>()
             .map { e -> "foo" to free("${e.i} > 123").asPureConditon() }
             .distinct()
@@ -245,7 +245,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
       }
 
       "pure map-clause - double element" {
-        val q = capture {
+        val q = sql {
           Table<Ent>()
             .map { e -> free("${e.i} > 123").asPureConditon() }
             .distinct()
@@ -297,7 +297,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
       data class Ent(val name: String, val i: Int, val b: Boolean)
 
       "filter-clause" {
-        val q = capture {
+        val q = sql {
           Table<Ent>().filter { e -> free("SomeUdf(${e.i})")<Boolean>() }
         }
         shouldBeGolden(q.xr, "XR")
@@ -305,7 +305,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
       }
 
       "map-clause - impure" {
-        val q = capture {
+        val q = sql {
           Table<Ent>()
             .map { e -> free("SomeUdf(${e.i})")<Int>() }
             .map { x -> x + 1 }
@@ -315,7 +315,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
       }
 
       "map-clause - pure" {
-        val q = capture {
+        val q = sql {
           Table<Ent>()
             .map { e -> free("SomeUdf(${e.i})").asPure<Int>() }
             .map { x -> x + 1 }
@@ -361,7 +361,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     data class Product(val id: Long, val desc: String, val sku: Int)
 
     "first parameter" {
-      val q = capture {
+      val q = sql {
         Table<Product>().filter { p -> param("1").toInt() == p.sku }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
@@ -369,7 +369,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "second parameter" {
-      val q = capture {
+      val q = sql {
         Table<Product>().filter { p -> p.sku == param("1").toInt() }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
@@ -377,7 +377,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "both parameters" {
-      val q = capture {
+      val q = sql {
         Table<Product>().filter { p -> param("2").toInt() == param("1").toInt() }
       }.determinizeDynamics()
       shouldBeGolden(q.xr, "XR")
@@ -390,7 +390,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     data class TestEntity2(val i: Int, val s: String)
 
     "for-comprehension with constant" {
-      val q = capture.select {
+      val q = sql.select {
         val t1 = from(Table<TestEntity>())
         val t2 = join(Table<TestEntity>()) { t -> true }
         t1 to t2
@@ -400,7 +400,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "for-comprehension with field" {
-      val q = capture.select {
+      val q = sql.select {
         val t1 = from(Table<TestEntity>())
         val t2 = join(Table<TestEntity>()) { t -> t.b }
         t1 to t2
@@ -414,7 +414,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     data class TestEntity(val s: String, val i: Int, val l: Long, val o: Boolean?, val b: Boolean)
 
     "exists" {
-      val q = capture {
+      val q = sql {
         Table<TestEntity>()
           .filter { t -> if (t.o ?: false) false else true }
           .map { t -> t.b to true }
@@ -424,7 +424,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "exists - lifted contains" {
-      val q = capture {
+      val q = sql {
         Table<TestEntity>()
           // if (if (x == null) null else f(x)) == null) null else g(if (x == null) null else f(x))
           .filter { t -> t.o?.let { it == true } ?: false }
@@ -437,7 +437,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "exists - lifted not contains" {
-      val q = capture {
+      val q = sql {
         Table<TestEntity>()
           .filter { t -> t.o?.let { param(true) } ?: false } // { it -> true }.apply(t.o) -> true
           .map { t -> t.b to true }
@@ -449,7 +449,7 @@ class BooleanLiteralSupportSpec: GoldenSpecDynamic(BooleanLiteralSupportSpecGold
     }
 
     "exists - lifted complex" {
-      val q = capture {
+      val q = sql {
         Table<TestEntity>()
           .filter { t -> t.o?.let { if (param(false)) param(false) else param(true) } ?: false }
           .map { t -> t.b to true }

--- a/testing/src/commonTest/kotlin/io/exoquery/BuildPrettyReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/BuildPrettyReq.kt
@@ -1,8 +1,5 @@
 package io.exoquery
 
-import io.exoquery.annotation.CapturedFunction
-import io.exoquery.sql.PostgresDialect
-
 // Note that the 1st time you overwrite the golden file it will still fail because the compile is using teh old version
 // Also note that it won't actually override the BasicQuerySanitySpecGolden file unless you change this one
 
@@ -12,7 +9,7 @@ class BuildPrettyReq: GoldenSpecDynamic(BuildPrettyReqGoldenDynamic, Mode.ExoGol
   data class Address(val ownerId: Int, val street: String, val city: String)
 
   "select with join" {
-    val people = capture.select {
+    val people = sql.select {
       val p = from(Table<Person>())
       val a = join(Table<Address>()) { a -> a.ownerId == p.id }
       Pair(p.name, a.street)

--- a/testing/src/commonTest/kotlin/io/exoquery/CaptureSelectFilterReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/CaptureSelectFilterReq.kt
@@ -7,24 +7,24 @@ import io.exoquery.annotation.TracesEnabled
 import io.exoquery.util.TraceType
 
 class CaptureSelectFilterReq: GoldenSpecDynamic(CaptureSelectFilterReqGoldenDynamic, Mode.ExoGoldenTest(), {
-  "capture select.filter should expand correctly" - {
+  "sql select.filter should expand correctly" - {
     "test query" {
       data class User(val id: Int, val name: String, val active: Int)
       data class Comment(val id: Int, val userId: Int, val createdAt: Long)
       data class UserCommentCount(val user: User, val commentCount: Int)
 
-      val users = capture { Table<User>() }
-      val comments = capture { Table<Comment>() }
+      val users = sql { Table<User>() }
+      val comments = sql { Table<Comment>() }
 
-      val now = capture.expression {
+      val now = sql.expression {
         free("now()")<Long>()
       }
       @CapturedFunction
-      fun IntervalDay(days: Int) = capture.expression {
+      fun IntervalDay(days: Int) = sql.expression {
         free("interval '$days days'")<Long>()
       }
 
-      val q = capture {
+      val q = sql {
         select {
           val u = from(users)
           val c = joinLeft(comments) { it.userId == u.id }
@@ -41,11 +41,11 @@ class CaptureSelectFilterReq: GoldenSpecDynamic(CaptureSelectFilterReqGoldenDyna
     data class Person(val id: Int, val name: String, val age: Int)
     data class Address(val ownerId: Int, val street: String, val city: String)
 
-    "capture select.filter simple" {
-      val people = capture { Table<Person>() }
-      val addresses = capture { Table<Address>() }
+    "sql select.filter simple" {
+      val people = sql { Table<Person>() }
+      val addresses = sql { Table<Address>() }
 
-      val c = capture {
+      val c = sql {
         select {
           val p = from(people)
           where { p.age > 18 }
@@ -56,11 +56,11 @@ class CaptureSelectFilterReq: GoldenSpecDynamic(CaptureSelectFilterReqGoldenDyna
       shouldBeGolden(c.buildPrettyFor.Postgres(), useTokenRendering = false)
     }
 
-    "capture select(where,groupBy).filter" {
-      val people = capture { Table<Person>() }
-      val addresses = capture { Table<Address>() }
+    "sql select(where,groupBy).filter" {
+      val people = sql { Table<Person>() }
+      val addresses = sql { Table<Address>() }
 
-      val c = capture {
+      val c = sql {
         select {
           val p = from(people)
           val a = joinLeft(addresses) { it.ownerId == p.id }
@@ -74,11 +74,11 @@ class CaptureSelectFilterReq: GoldenSpecDynamic(CaptureSelectFilterReqGoldenDyna
     }
 
 
-    "capture select(where,groupBy).map" {
-      val people = capture { Table<Person>() }
-      val addresses = capture { Table<Address>() }
+    "sql select(where,groupBy).map" {
+      val people = sql { Table<Person>() }
+      val addresses = sql { Table<Address>() }
 
-      val c = capture {
+      val c = sql {
         select {
           val p = from(people)
           val a = joinLeft(addresses) { it.ownerId == p.id }

--- a/testing/src/commonTest/kotlin/io/exoquery/CaptureSelectFilterReqGoldenDynamic.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/CaptureSelectFilterReqGoldenDynamic.kt
@@ -6,10 +6,10 @@ import io.exoquery.printing.kt
 
 object CaptureSelectFilterReqGoldenDynamic: GoldenQueryFile {
   override val queries = mapOf<String, GoldenResult>(
-    "capture select filter should expand correctly/test query/XR" to kt(
+    "sql select filter should expand correctly/test query/XR" to kt(
       """select { val u = from(Table(User)); val c = leftJoin(Table(Comment)) { c.userId == u.id }; where(u.active == 1 && c.createdAt > free("now()").invoke() - { days -> free("interval ', ${'$'}days,  days'").invoke() }.apply(30)); groupBy(u); UserCommentCount(user = u, commentCount = count_GC(c.id)) }.filter { uc -> uc.commentCount > 5 }"""
     ),
-    "capture select filter should expand correctly/test query" to cr(
+    "sql select filter should expand correctly/test query" to cr(
       """
       SELECT
         uc.user_id AS id,
@@ -38,10 +38,10 @@ object CaptureSelectFilterReqGoldenDynamic: GoldenQueryFile {
         uc.commentCount > 5
       """
     ),
-    "capture select filter should expand correctly/capture select filter simple/XR" to kt(
+    "sql select filter should expand correctly/sql select filter simple/XR" to kt(
       "select { val p = from(Table(Person)); where(p.age > 18); p }.filter { ccc -> ccc.name == Main St }"
     ),
-    "capture select filter should expand correctly/capture select filter simple" to cr(
+    "sql select filter should expand correctly/sql select filter simple" to cr(
       """
       SELECT
         ccc.id,
@@ -62,10 +62,10 @@ object CaptureSelectFilterReqGoldenDynamic: GoldenQueryFile {
         ccc.name = 'Main St'
       """
     ),
-    "capture select filter should expand correctly/capture select(where,groupBy) filter/XR" to kt(
+    "sql select filter should expand correctly/sql select(where,groupBy) filter/XR" to kt(
       "select { val p = from(Table(Person)); val a = leftJoin(Table(Address)) { a.ownerId == p.id }; where(p.age > 18); groupBy(p); p }.filter { ccc -> ccc.name == Main St }"
     ),
-    "capture select filter should expand correctly/capture select(where,groupBy) filter" to cr(
+    "sql select filter should expand correctly/sql select(where,groupBy) filter" to cr(
       """
       SELECT
         ccc.id,
@@ -91,10 +91,10 @@ object CaptureSelectFilterReqGoldenDynamic: GoldenQueryFile {
         ccc.name = 'Main St'
       """
     ),
-    "capture select filter should expand correctly/capture select(where,groupBy) map/XR" to kt(
+    "sql select filter should expand correctly/sql select(where,groupBy) map/XR" to kt(
       "select { val p = from(Table(Person)); val a = leftJoin(Table(Address)) { a.ownerId == p.id }; where(p.age > 18); groupBy(p); p }.map { ccc -> Tuple(first = ccc.name, second = ccc.age) }"
     ),
-    "capture select filter should expand correctly/capture select(where,groupBy) map" to cr(
+    "sql select filter should expand correctly/sql select(where,groupBy) map" to cr(
       """
       SELECT
         p.name AS first,

--- a/testing/src/commonTest/kotlin/io/exoquery/CapturedDynamicSplicingReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/CapturedDynamicSplicingReq.kt
@@ -1,14 +1,7 @@
 package io.exoquery
 
 import io.exoquery.annotation.CapturedDynamic
-import io.exoquery.sql.PostgresDialect
 import io.exoquery.testdata.Person
-import io.exoquery.xr.`+++`
-import io.exoquery.xr.XR
-import io.exoquery.xr.XRType
-import io.exoquery.xr.rekeyRuntimeBinds
-import io.exoquery.xr.spliceQuotations
-import io.kotest.matchers.equals.shouldBeEqual
 
 class CapturedDynamicSplicingReq : GoldenSpecDynamic(CapturedDynamicSplicingReqGoldenDynamic, Mode.ExoGoldenTest(), {
 //  "dynamic catpured function with join clauses" {
@@ -16,11 +9,11 @@ class CapturedDynamicSplicingReq : GoldenSpecDynamic(CapturedDynamicSplicingReqG
 //
 //    @CapturedDynamic
 //    fun joinedClauses(p: SqlExpression<Person>) =
-//      possibleNames.map { n -> capture.expression { p.use.name == param(n) } }
-//        .reduce { a, b -> capture.expression { a.use || b.use } }
+//      possibleNames.map { n -> sql.expression { p.use.name == param(n) } }
+//        .reduce { a, b -> sql.expression { a.use || b.use } }
 //
-//    val filteredPeople = capture {
-//      Table<Person>().filter { p -> joinedClauses(capture.expression { p }).use }
+//    val filteredPeople = sql {
+//      Table<Person>().filter { p -> joinedClauses(sql.expression { p }).use }
 //    }
 //
 //    // Splice in the runtime quotes and reconstruct the query so we can golden-test it
@@ -36,19 +29,19 @@ class CapturedDynamicSplicingReq : GoldenSpecDynamic(CapturedDynamicSplicingReqG
   "dynamic captured expression" {
     //@CapturedDynamic
     //fun nameLowerCaseSql(name: String) =
-    //  capture.expression { param(name).sql.lowercase() }
+    //  sql.expression { param(name).sql.lowercase() }
 
-    //val query = capture {
+    //val query = sql {
     //  Table<Person>().filter { p -> p.name == nameLowerCaseSql(p.name).use }
     //}
 
 
     @CapturedDynamic
     fun nameLowerCaseSql(name: SqlExpression<String>) =
-      capture.expression { name.use.sql.lowercase() }
+      sql.expression { name.use.sql.lowercase() }
 
-    val query = capture {
-      Table<Person>().filter { p -> p.name == nameLowerCaseSql(capture.expression { p.name }).use }
+    val query = sql {
+      Table<Person>().filter { p -> p.name == nameLowerCaseSql(sql.expression { p.name }).use }
     }
 
     println(query.determinizeDynamics())

--- a/testing/src/commonTest/kotlin/io/exoquery/CapturedFunctionSpec.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/CapturedFunctionSpec.kt
@@ -9,11 +9,11 @@ import io.kotest.core.spec.style.FreeSpec
  * This is for CapturedFunction tests involving behavior and deep IR checks. The comprehensive tests are in CapturedFunctionReq.kt.
  */
 class CapturedFunctionSpec : FreeSpec({
-  "static function capture - structural tests" - {
-    "proto function-capture i.e. call without capture" {
+  "static function sql - structural tests" - {
+    "proto function-sql i.e. call without sql" {
       @CapturedFunction
-      fun joes(people: SqlQuery<Person>) = capture { people.filter { p -> p.name == "Joe" } }
-      val people = capture { Table<Person>() }
+      fun joes(people: SqlQuery<Person>) = sql { people.filter { p -> p.name == "Joe" } }
+      val people = sql { Table<Person>() }
       shouldThrow<MissingCaptureError> { joes(people) }
     }
   }

--- a/testing/src/commonTest/kotlin/io/exoquery/CrossFileCompileTimeQueryReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/CrossFileCompileTimeQueryReq.kt
@@ -1,12 +1,12 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 class CrossFileCompileTimeQueryReq : GoldenSpecDynamic(CrossFileCompileTimeQueryReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "compile-time queries should work for" - {
     "regular functions" - {
       "inline functions defined in previous compilation units" {
-        val q = capture {
+        val q = sql {
           crossFileSelect().filter { pair -> pair.first.name == "JoeOuter" }
         }
         val result = q.build<PostgresDialect>()
@@ -15,7 +15,7 @@ class CrossFileCompileTimeQueryReq : GoldenSpecDynamic(CrossFileCompileTimeQuery
         shouldBeGolden(result.debugData.phase.toString(), "Phase")
       }
       "inline functions defined in previous-previous compilation units" {
-        val q = capture {
+        val q = sql {
           crossFileSelectSelect().filter { pair -> pair.first.first.name == "JoeOuter" }
         }
         val result = q.build<PostgresDialect>()
@@ -24,7 +24,7 @@ class CrossFileCompileTimeQueryReq : GoldenSpecDynamic(CrossFileCompileTimeQuery
         shouldBeGolden(result.debugData.phase.toString(), "Phase")
       }
       "inline functions defined in previous-previous compilation units" {
-        val q = capture {
+        val q = sql {
           crossFileSelectExpr().filter { pair -> pair.first.name == "JoeOuter" }
         }
         val result = q.build<PostgresDialect>()
@@ -56,7 +56,7 @@ class CrossFileCompileTimeQueryReq : GoldenSpecDynamic(CrossFileCompileTimeQuery
     }
     "captured functions" - {
       "inline captured functions defined in previous compilation units" {
-        val q = capture {
+        val q = sql {
           crossFileCapSelect(Table<PersonCrs>().filter { p -> p.name == "JoeInner" })
             .filter { pair -> pair.name == "JoeOuter" }
         }
@@ -66,7 +66,7 @@ class CrossFileCompileTimeQueryReq : GoldenSpecDynamic(CrossFileCompileTimeQuery
         shouldBeGolden(result.debugData.phase.toString(), "Phase")
       }
       "inline captured functions defined in previous-previous compilation units" {
-        val q = capture {
+        val q = sql {
           crossFileCapSelectCapSelect(
             Table<PersonCrs>().filter { p -> p.name == "JoeInner" }
           ).filter { pair -> pair.first.name == "JoeOuter" }
@@ -77,7 +77,7 @@ class CrossFileCompileTimeQueryReq : GoldenSpecDynamic(CrossFileCompileTimeQuery
         shouldBeGolden(result.debugData.phase.toString(), "Phase")
       }
       "inline captured functions defined in previous-previous(expr) compilation units" {
-        val q = capture {
+        val q = sql {
           crossFileCapSelectCapExpr(
             Table<PersonCrs>().filter { p -> p.name == "JoeInner" }
           ).filter { pair -> pair.name == "JoeOuter" }
@@ -91,7 +91,7 @@ class CrossFileCompileTimeQueryReq : GoldenSpecDynamic(CrossFileCompileTimeQuery
     // TODO not currently supported, need to think about how to allow this
     //"runtime functions" - {
     //  "inline runtime functions defined in previous compilation units" {
-    //    val q = capture {
+    //    val q = sql {
     //      crossFileDynSelect(Table<PersonCrs>().filter { p -> p.name == "JoeInner" })
     //        .filter { pair -> pair.name == "JoeOuter" }
     //    }
@@ -101,7 +101,7 @@ class CrossFileCompileTimeQueryReq : GoldenSpecDynamic(CrossFileCompileTimeQuery
     //    shouldBeGolden(result.debugData.phase.toString(), "Phase")
     //  }
     //  "inline runtime functions defined in previous-previous compilation units" {
-    //    val q = capture {
+    //    val q = sql {
     //      crossFileDynSelectDynSelect(
     //        Table<PersonCrs>().filter { p -> p.name == "JoeInner" }
     //      ).filter { pair -> pair.first.name == "JoeOuter" }
@@ -116,7 +116,7 @@ class CrossFileCompileTimeQueryReq : GoldenSpecDynamic(CrossFileCompileTimeQuery
 
   "compile-time expressions should work for" - {
     "inline functions defined in previous compilation units" {
-      val q = capture {
+      val q = sql {
         crossFileExpr().filter { it.name == "JoeExprOuter"  }
       }
       val result = q.build<PostgresDialect>()
@@ -125,7 +125,7 @@ class CrossFileCompileTimeQueryReq : GoldenSpecDynamic(CrossFileCompileTimeQuery
       shouldBeGolden(result.debugData.phase.toString(), "Phase")
     }
     "inline functions defined in previous-previous compilation units" {
-      val q = capture {
+      val q = sql {
         crossFileExprExpr().filter { it.name == "JoeExprOuter"  }
       }
       val result = q.build<PostgresDialect>()

--- a/testing/src/commonTest/kotlin/io/exoquery/DealiasBugSpec.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/DealiasBugSpec.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 /**
  * The purpose of this test was to originally test a bug that occurred when we had a
@@ -17,8 +17,8 @@ class DealiasBugSpec: GoldenSpecDynamic(DealiasBugSpecGoldenDynamic, Mode.ExoGol
   "column names in a subquery with same sub-name (original bug case)" {
     data class MyTable(val id: Int, val user: String)
     data class MySubTable(val user: MyTable, val id: Int)
-    val q = capture.select {
-      val t = from(capture.select {
+    val q = sql.select {
+      val t = from(sql.select {
         val tt = from(Table<MyTable>())
         where { tt.id == 123 }
         MySubTable(tt, tt.id)
@@ -33,8 +33,8 @@ class DealiasBugSpec: GoldenSpecDynamic(DealiasBugSpecGoldenDynamic, Mode.ExoGol
   "column names in a subquery with differnet sub-names" {
     data class MyTable(val id: Int, val user: String)
     data class MySubTable(val otherOther: MyTable, val id: Int)
-    val q = capture.select {
-      val t = from(capture.select {
+    val q = sql.select {
+      val t = from(sql.select {
         val tt = from(Table<MyTable>())
         where { tt.id == 123 }
         MySubTable(tt, tt.id)
@@ -49,8 +49,8 @@ class DealiasBugSpec: GoldenSpecDynamic(DealiasBugSpecGoldenDynamic, Mode.ExoGol
   "column names in a subquery with same names but no where-clause" {
     data class MyTable(val id: Int, val user: String)
     data class MySubTable(val otherOther: MyTable, val id: Int)
-    val q = capture.select {
-      val t = from(capture.select {
+    val q = sql.select {
+      val t = from(sql.select {
         val tt = from(Table<MyTable>())
         MySubTable(tt, tt.id)
       })

--- a/testing/src/commonTest/kotlin/io/exoquery/EmbeddedDistinctReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/EmbeddedDistinctReq.kt
@@ -2,7 +2,7 @@ package io.exoquery
 
 import io.exoquery.annotation.ExoEntity
 import io.exoquery.annotation.ExoField
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 class EmbeddedDistinctReq: GoldenSpecDynamic(EmbeddedDistinctReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "queries with embedded entities should" - {
@@ -30,7 +30,7 @@ class EmbeddedDistinctReq: GoldenSpecDynamic(EmbeddedDistinctReqGoldenDynamic, M
       data class Emb(val a: Int, val b: Int)
       data class Parent(val id: Int, val emb1: Emb)
 
-      val q = capture {
+      val q = sql {
         Table<Emb>().map { e -> Parent(1, e) }.distinct()
       }
       shouldBeGolden(q.xr, "XR")
@@ -41,7 +41,7 @@ class EmbeddedDistinctReq: GoldenSpecDynamic(EmbeddedDistinctReqGoldenDynamic, M
       @ExoEntity("EMB") data class Emb(@ExoField("A") val a: Int, @ExoField("B") val b: Int)
       data class Parent(@ExoField("ID") val id: Int, val emb1: Emb)
 
-      val q = capture {
+      val q = sql {
         Table<Emb>().map { e -> Parent(1, e) }.distinct()
       }
       shouldBeGolden(q.xr, "XR")
@@ -52,7 +52,7 @@ class EmbeddedDistinctReq: GoldenSpecDynamic(EmbeddedDistinctReqGoldenDynamic, M
       data class Emb(val a: Int, val b: Int)
       data class Parent(val id: Int, val emb1: Emb)
 
-      val q = capture {
+      val q = sql {
         Table<Emb>().map { e -> Parent(1, e) }.distinct().map { p -> 2 to p }.distinct()
       }
       shouldBeGolden(q.xr, "XR")
@@ -72,7 +72,7 @@ class EmbeddedDistinctReq: GoldenSpecDynamic(EmbeddedDistinctReqGoldenDynamic, M
       data class Emb(val a: Int, val b: Int)
       data class Parent(val id: Int, val emb1: Emb)
 
-      val q = capture {
+      val q = sql {
         Table<Emb>().map { e -> 1 to e }.distinct().map { t -> Parent(t.first, t.second) }.distinct()
       }
       shouldBeGolden(q.xr, "XR")
@@ -84,7 +84,7 @@ class EmbeddedDistinctReq: GoldenSpecDynamic(EmbeddedDistinctReqGoldenDynamic, M
       data class Parent(val idP: Int, val emb1: Emb)
       data class Grandparent(val idG: Int, val par: Parent)
 
-      val q = capture {
+      val q = sql {
         Table<Emb>().map { e -> Parent(1, e) }.distinct().map { p -> Grandparent(2, p) }.distinct()
       }
       shouldBeGolden(q.xr, "XR")
@@ -96,7 +96,7 @@ class EmbeddedDistinctReq: GoldenSpecDynamic(EmbeddedDistinctReqGoldenDynamic, M
       data class Parent(val idP: Int, val emb1: Emb)
       data class Grandparent(val idG: Int, val par: Parent)
 
-      val q = capture {
+      val q = sql {
         // Not right result. Need to debug this
         Table<Emb>().map { e -> Parent(1, e) }.distinct().map { p -> Grandparent(2, p) }.distinct().map { g -> 3 to g }
           .distinct()
@@ -110,7 +110,7 @@ class EmbeddedDistinctReq: GoldenSpecDynamic(EmbeddedDistinctReqGoldenDynamic, M
       data class Parent(val idP: Int, val emb1: Emb)
       data class Grandparent(val idG: Int, val par: Parent)
 
-      val q = capture {
+      val q = sql {
         // Not right result. Need to debug this
         Table<Emb>().map { e -> Parent(1, e) }.distinct().map { p -> Grandparent(2, p) }.distinct().map { g -> 3 to g }
           .distinct()
@@ -125,7 +125,7 @@ class EmbeddedDistinctReq: GoldenSpecDynamic(EmbeddedDistinctReqGoldenDynamic, M
       data class Parent(@ExoField("idPREN") val idP: Int, @ExoField("emb1REN") val emb1: Emb)
       data class Grandparent(val idG: Int, val par: Parent)
 
-      val q = capture {
+      val q = sql {
         // Not right result. Need to debug this
         Table<Emb>().map { e -> Parent(1, e) }.distinct().map { p -> Grandparent(2, p) }.distinct().map { g -> 3 to g }
           .distinct()

--- a/testing/src/commonTest/kotlin/io/exoquery/ExpectedErrorSpec.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ExpectedErrorSpec.kt
@@ -8,9 +8,9 @@ import io.kotest.core.spec.style.FreeSpec
 //object CapturedFunctionParamError {
 //  @CapturedFunction
 //  fun capFunc(value: Int) =
-//    capture.expression { param(value) } // Error: Captured function cannot have non-expression parameters
+//    sql.expression { param(value) } // Error: Captured function cannot have non-expression parameters
 //
-//  val q = capture {
+//  val q = sql {
 //    Table<Person>().filter { p -> capFunc(p.id).use == 1 }
 //  }
 //}
@@ -18,9 +18,9 @@ import io.kotest.core.spec.style.FreeSpec
 //object CapturedDynamicParamError {
 //  @CapturedDynamic
 //  fun capFunc(value: Int) =
-//    capture.expression { param(value) } // Error: Captured function cannot have non-expression parameters
+//    sql.expression { param(value) } // Error: Captured function cannot have non-expression parameters
 //
-//  val q = capture {
+//  val q = sql {
 //    Table<Person>().filter { p -> capFunc(p.id).use == 1 }
 //  }
 //}
@@ -28,9 +28,9 @@ import io.kotest.core.spec.style.FreeSpec
 //object CapturedDynamicWrongParamTypeError {
 //  @CapturedDynamic
 //  fun capFunc(value: Int) =
-//    capture.expression { value }
+//    sql.expression { value }
 //
-//  val q = capture {
+//  val q = sql {
 //    Table<Person>().filter { p -> capFunc(p.id).use == 1 }
 //  }
 //}

--- a/testing/src/commonTest/kotlin/io/exoquery/ExpressionFunctionReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ExpressionFunctionReq.kt
@@ -1,80 +1,80 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Person
 
 class ExpressionFunctionReq : GoldenSpecDynamic(ExpressionFunctionReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "String" - {
     "toInt" {
-      val q = capture { Table<Person>().map { p -> p.name.toInt() } }
+      val q = sql { Table<Person>().map { p -> p.name.toInt() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "toLong" {
-      val q = capture { Table<Person>().map { p -> p.name.toLong() } }
+      val q = sql { Table<Person>().map { p -> p.name.toLong() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "toBoolean" {
-      val q = capture { Table<Person>().map { p -> p.name.toBoolean() } }
+      val q = sql { Table<Person>().map { p -> p.name.toBoolean() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "casting" {
-      val q = capture { Table<Person>().map { p -> p.name + (p.age as String) } }
+      val q = sql { Table<Person>().map { p -> p.name + (p.age as String) } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "string concat" {
-      val q = capture { Table<Person>().map { p -> p.name + " " + p.name } }
+      val q = sql { Table<Person>().map { p -> p.name + " " + p.name } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "substr - regular" {
-      val q = capture { Table<Person>().map { p -> p.name.substring(1, 2) } }
+      val q = sql { Table<Person>().map { p -> p.name.substring(1, 2) } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "substr" {
-      val q = capture { Table<Person>().map { p -> p.name.sql.substring(1, 2) } }
+      val q = sql { Table<Person>().map { p -> p.name.sql.substring(1, 2) } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "left" {
-      val q = capture { Table<Person>().map { p -> p.name.sql.left(2) } }
+      val q = sql { Table<Person>().map { p -> p.name.sql.left(2) } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "right" {
-      val q = capture { Table<Person>().map { p -> p.name.sql.right(2) } }
+      val q = sql { Table<Person>().map { p -> p.name.sql.right(2) } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "replace" {
-      val q = capture { Table<Person>().map { p -> p.name.sql.replace("a", "b") } }
+      val q = sql { Table<Person>().map { p -> p.name.sql.replace("a", "b") } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
 // TODO method whitelist for this case
 //    "upper" {
-//      val q = capture { Table<Person>().map { p -> p.name.uppercase() } }
+//      val q = sql { Table<Person>().map { p -> p.name.uppercase() } }
 //      shouldBeGolden(q.build<PostgresDialect>())
 //    }
     "upper - sql" {
-      val q = capture { Table<Person>().map { p -> p.name.sql.uppercase() } }
+      val q = sql { Table<Person>().map { p -> p.name.sql.uppercase() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
 // TODO method whitelist for this case
 //    "lower" {
-//      val q = capture { Table<Person>().map { p -> p.name.lowercase() } }
+//      val q = sql { Table<Person>().map { p -> p.name.lowercase() } }
 //      shouldBeGolden(q.build<PostgresDialect>())
 //    }
     "lower - sql" {
-      val q = capture { Table<Person>().map { p -> p.name.sql.lowercase() } }
+      val q = sql { Table<Person>().map { p -> p.name.sql.lowercase() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
   }
   "StringInterpolation" - {
     "multiple elements" {
-      val q = capture { Table<Person>().map { p -> "${p.name}-${p.age}" } }
+      val q = sql { Table<Person>().map { p -> "${p.name}-${p.age}" } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "single element" {
-      val q = capture { Table<Person>().map { p -> "${p.name}" } }
+      val q = sql { Table<Person>().map { p -> "${p.name}" } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "single constant" {
-      val q = capture { Table<Person>().map { p -> "${"constant"}" } }
+      val q = sql { Table<Person>().map { p -> "${"constant"}" } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "many elements" {
@@ -84,7 +84,7 @@ class ExpressionFunctionReq : GoldenSpecDynamic(ExpressionFunctionReqGoldenDynam
         val address: String,
         val phone: String
       )
-      val q = capture { Table<LotsOfFields>().map { l ->
+      val q = sql { Table<LotsOfFields>().map { l ->
         "${l.name}-foo-${l.age}-bar-${l.address}-baz-${l.phone}-blin"
       } }
       shouldBeGolden(q.build<PostgresDialect>())
@@ -92,44 +92,44 @@ class ExpressionFunctionReq : GoldenSpecDynamic(ExpressionFunctionReqGoldenDynam
   }
   "Int" - {
     "toLong" {
-      val q = capture { Table<Person>().map { p -> p.age.toLong() } }
+      val q = sql { Table<Person>().map { p -> p.age.toLong() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "toDouble" {
-      val q = capture { Table<Person>().map { p -> p.age.toDouble() } }
+      val q = sql { Table<Person>().map { p -> p.age.toDouble() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "toFloat" {
-      val q = capture { Table<Person>().map { p -> p.age.toFloat() } }
+      val q = sql { Table<Person>().map { p -> p.age.toFloat() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
   }
   "Long" - {
     "toInt" {
-      val q = capture { Table<Person>().map { p -> p.age.toInt() } }
+      val q = sql { Table<Person>().map { p -> p.age.toInt() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "toDouble" {
-      val q = capture { Table<Person>().map { p -> p.age.toDouble() } }
+      val q = sql { Table<Person>().map { p -> p.age.toDouble() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "toFloat" {
-      val q = capture { Table<Person>().map { p -> p.age.toFloat() } }
+      val q = sql { Table<Person>().map { p -> p.age.toFloat() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
   }
   "Float" - {
     "toInt" {
-      val q = capture { Table<Person>().map { p -> p.age.toInt() } }
+      val q = sql { Table<Person>().map { p -> p.age.toInt() } }
       shouldBeGolden(q.build<PostgresDialect>())
       println("hello")
     }
     "toLong" {
-      val q = capture { Table<Person>().map { p -> p.age.toLong() } }
+      val q = sql { Table<Person>().map { p -> p.age.toLong() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
     "toDouble" {
-      val q = capture { Table<Person>().map { p -> p.age.toDouble() } }
+      val q = sql { Table<Person>().map { p -> p.age.toDouble() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
   }

--- a/testing/src/commonTest/kotlin/io/exoquery/FreeReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/FreeReq.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Person
 
 class FreeReq: GoldenSpecDynamic(FreeReqGoldenDynamic, Mode.ExoGoldenTest(), {
@@ -8,43 +8,43 @@ class FreeReq: GoldenSpecDynamic(FreeReqGoldenDynamic, Mode.ExoGoldenTest(), {
   // TODO if 'free' not follorwed by anything there should be some kidn of compile error
   "static free" - {
     "simple sql function" {
-      shouldBeGolden(capture { Table<Person>().filter { p -> free("MyFunction(${p.age})")<Boolean>() } }.build<PostgresDialect>())
+      shouldBeGolden(sql { Table<Person>().filter { p -> free("MyFunction(${p.age})")<Boolean>() } }.build<PostgresDialect>())
     }
     "simple sql function - pure" {
-      shouldBeGolden(capture { Table<Person>().filter { p -> free("MyFunction(${p.age})").asPure<Boolean>() } }.build<PostgresDialect>())
+      shouldBeGolden(sql { Table<Person>().filter { p -> free("MyFunction(${p.age})").asPure<Boolean>() } }.build<PostgresDialect>())
     }
     "simple sql function - condition" {
-      shouldBeGolden(capture { Table<Person>().filter { p -> free("MyFunction(${p.age})").asConditon() } }.build<PostgresDialect>())
+      shouldBeGolden(sql { Table<Person>().filter { p -> free("MyFunction(${p.age})").asConditon() } }.build<PostgresDialect>())
     }
     "simple sql function - condition" {
-      shouldBeGolden(capture { Table<Person>().filter { p -> free("MyFunction(${p.age})").asPureConditon() } }.build<PostgresDialect>())
+      shouldBeGolden(sql { Table<Person>().filter { p -> free("MyFunction(${p.age})").asPureConditon() } }.build<PostgresDialect>())
     }
   }
 
   "query with free" - {
     "static query in free" {
-      val query = capture {
+      val query = sql {
         Table<Person>().filter { p -> p.name == "Joe" }
       }
-      val free = capture {
+      val free = sql {
         free("beforeStuff() ${query} afterStuff()").asPure<SqlAction<Person, Long>>()
       }
       shouldBeGolden(free.build<PostgresDialect>())
     }
 
     "dynamic query in free" {
-      val query = capture {
+      val query = sql {
         Table<Person>().filter { p -> p.name == "Joe" }
       }.dyanmic()
 
-      val free = capture {
+      val free = sql {
         free("beforeStuff() ${query} afterStuff()").asPure<SqlAction<Person, Long>>()
       }
       shouldBeGolden(free.build<PostgresDialect>())
     }
 
     "direct query in free" {
-      val free = capture {
+      val free = sql {
         free("beforeStuff() ${Table<Person>().filter { p -> p.name == "Joe" }} afterStuff()").asPure<SqlAction<Person, Long>>()
       }
       shouldBeGolden(free.build<PostgresDialect>())
@@ -53,26 +53,26 @@ class FreeReq: GoldenSpecDynamic(FreeReqGoldenDynamic, Mode.ExoGoldenTest(), {
 
   "action with free" - {
     "static action in free" {
-      val action = capture {
+      val action = sql {
         insert<Person> { setParams(Person(1, "Joe", 123)) }
       }
-      val free = capture {
+      val free = sql {
         free("beforeStuff() ${action} afterStuff()").asPure<SqlAction<Person, Long>>()
       }
       shouldBeGolden(free.build<PostgresDialect>().determinizeDynamics())
     }
     "dynamic action in free" {
-      val action = capture {
+      val action = sql {
         insert<Person> { setParams(Person(1, "Joe", 123)) }
       }.dyanmic()
 
-      val free = capture {
+      val free = sql {
         free("beforeStuff() ${action} afterStuff()").asPure<SqlAction<Person, Long>>()
       }
       shouldBeGolden(free.build<PostgresDialect>().determinizeDynamics())
     }
     "direct action in free" {
-      val free = capture {
+      val free = sql {
         free(
           "beforeStuff() ${
             insert<Person> {
@@ -90,7 +90,7 @@ class FreeReq: GoldenSpecDynamic(FreeReqGoldenDynamic, Mode.ExoGoldenTest(), {
       shouldBeGolden(free.build<PostgresDialect>().determinizeDynamics())
     }
     "whole action in free" {
-      val action = capture {
+      val action = sql {
         free(
           """
             CREATE TABLE Launch (

--- a/testing/src/commonTest/kotlin/io/exoquery/GoldenSpec.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/GoldenSpec.kt
@@ -3,7 +3,7 @@ package io.exoquery
 import io.exoquery.annotation.ExoExtras
 import io.exoquery.printing.PrintableValue
 import io.exoquery.printing.QueryFileKotlinMaker
-import io.exoquery.sql.Renderer
+import io.exoquery.lang.Renderer
 import io.exoquery.xr.XR
 import io.kotest.core.spec.DslDrivenSpec
 import io.kotest.core.spec.style.FreeSpec

--- a/testing/src/commonTest/kotlin/io/exoquery/MonadicMachineryReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/MonadicMachineryReq.kt
@@ -1,22 +1,22 @@
 package io.exoquery
 
 import io.exoquery.annotation.CapturedFunction
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Address
 import io.exoquery.testdata.Person
 import io.exoquery.testdata.Robot
 
 class MonadicMachineryReq: GoldenSpecDynamic(MonadicMachineryReqGoldenDynamic, Mode.ExoGoldenTest(), {
-  "capture.expression.(Row)->Table" {
-    val joinAddress = capture.expression {
+  "sql.expression.(Row)->Table" {
+    val joinAddress = sql.expression {
       { p: Person -> internal.flatJoin(Table<Address>()) { a -> p.id == a.ownerId } }
     }
 
-    val joinRobot = capture.expression {
+    val joinRobot = sql.expression {
       { p: Person -> internal.flatJoin(Table<Robot>()) { r -> p.id == r.ownerId } }
     }
 
-    val cap = capture.select {
+    val cap = sql.select {
       val p = from(Table<Person>())
       val a = from(joinAddress.use(p))
       val r = from(joinRobot.use(p))
@@ -26,18 +26,18 @@ class MonadicMachineryReq: GoldenSpecDynamic(MonadicMachineryReqGoldenDynamic, M
     shouldBeGolden(cap.xr, "XR")
     shouldBeGolden(cap.build<PostgresDialect>(), "SQL")
   }
-  "capture.expression.(@Cap (Row)->Table).use" {
+  "sql.expression.(@Cap (Row)->Table).use" {
     @CapturedFunction
-    fun joinAddress(p: Person) = capture.expression {
+    fun joinAddress(p: Person) = sql.expression {
       internal.flatJoin(Table<Address>()) { a -> p.id == a.ownerId }
     }
 
     @CapturedFunction
-    fun joinRobot(p: Person) = capture.expression {
+    fun joinRobot(p: Person) = sql.expression {
       internal.flatJoin(Table<Robot>()) { r -> p.id == r.ownerId }
     }
 
-    val cap = capture.select {
+    val cap = sql.select {
       val p = from(Table<Person>())
       val a = from(joinAddress(p).use)
       val r = from(joinRobot(p).use)
@@ -47,18 +47,18 @@ class MonadicMachineryReq: GoldenSpecDynamic(MonadicMachineryReqGoldenDynamic, M
     shouldBeGolden(cap.xr, "XR")
     shouldBeGolden(cap.build<PostgresDialect>(), "SQL")
   }
-  "capture.expression.use.(@Cap (Row)()->Table)" {
+  "sql.expression.use.(@Cap (Row)()->Table)" {
     @CapturedFunction
-    fun Person.joinAddress() = capture.expression {
+    fun Person.joinAddress() = sql.expression {
       internal.flatJoin(Table<Address>()) { a -> this@joinAddress.id == a.ownerId }
     }
 
     @CapturedFunction
-    fun Person.joinRobot() = capture.expression {
+    fun Person.joinRobot() = sql.expression {
       internal.flatJoin(Table<Robot>()) { r -> this@joinRobot.id == r.ownerId }
     }
 
-    val cap = capture.select {
+    val cap = sql.select {
       val p = from(Table<Person>())
       val a = from(p.joinAddress().use)
       val r = from(p.joinRobot().use)
@@ -69,18 +69,18 @@ class MonadicMachineryReq: GoldenSpecDynamic(MonadicMachineryReqGoldenDynamic, M
     shouldBeGolden(cap.build<PostgresDialect>(), "SQL")
   }
 
-  "capture.(@Cap (Row)()->Table)" {
+  "sql.(@Cap (Row)()->Table)" {
     @CapturedFunction
-    fun Person.joinAddress() = capture {
+    fun Person.joinAddress() = sql {
       internal.flatJoin(Table<Address>()) { a -> this@joinAddress.id == a.ownerId }
     }
 
     @CapturedFunction
-    fun Person.joinRobot() = capture {
+    fun Person.joinRobot() = sql {
       internal.flatJoin(Table<Robot>()) { r -> this@joinRobot.id == r.ownerId }
     }
 
-    val cap = capture.select {
+    val cap = sql.select {
       val p = from(Table<Person>())
       val a = from(p.joinAddress())
       val r = from(p.joinRobot())

--- a/testing/src/commonTest/kotlin/io/exoquery/MonadicMachineryReqGoldenDynamic.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/MonadicMachineryReqGoldenDynamic.kt
@@ -6,28 +6,28 @@ import io.exoquery.printing.kt
 
 object MonadicMachineryReqGoldenDynamic: GoldenQueryFile {
   override val queries = mapOf<String, GoldenResult>(
-    "capture expression (Row)->Table/XR" to kt(
+    "sql expression (Row)->Table/XR" to kt(
       "select { val p = from(Table(Person)); val a = from({ p -> Table(Address).join { a -> p.id == a.ownerId }.toExpr }.apply(p)); val r = from({ p -> Table(Robot).join { r -> p.id == r.ownerId }.toExpr }.apply(p)); Triple(first = p, second = a, third = r) }"
     ),
-    "capture expression (Row)->Table/SQL" to cr(
+    "sql expression (Row)->Table/SQL" to cr(
       "SELECT p.id, p.name, p.age, a.ownerId, a.street, a.city, r.ownerId, r.name, r.model FROM Person p INNER JOIN Address a ON p.id = a.ownerId INNER JOIN Robot r ON p.id = r.ownerId"
     ),
-    "capture expression (@Cap (Row)->Table) use/XR" to kt(
+    "sql expression (@Cap (Row)->Table) use/XR" to kt(
       "select { val p = from(Table(Person)); val a = from({ p -> Table(Address).join { a -> p.id == a.ownerId }.toExpr }.apply(p).toQuery); val r = from({ p -> Table(Robot).join { r -> p.id == r.ownerId }.toExpr }.apply(p).toQuery); Triple(first = p, second = a, third = r) }"
     ),
-    "capture expression (@Cap (Row)->Table) use/SQL" to cr(
+    "sql expression (@Cap (Row)->Table) use/SQL" to cr(
       "SELECT p.id, p.name, p.age, a.ownerId, a.street, a.city, r.ownerId, r.name, r.model FROM Person p INNER JOIN Address a ON p.id = a.ownerId INNER JOIN Robot r ON p.id = r.ownerId"
     ),
-    "capture expression use (@Cap (Row)()->Table)/XR" to kt(
+    "sql expression use (@Cap (Row)()->Table)/XR" to kt(
       "select { val p = from(Table(Person)); val a = from({ this -> Table(Address).join { a -> this.id == a.ownerId }.toExpr }.apply(p).toQuery); val r = from({ this -> Table(Robot).join { r -> this.id == r.ownerId }.toExpr }.apply(p).toQuery); Triple(first = p, second = a, third = r) }"
     ),
-    "capture expression use (@Cap (Row)()->Table)/SQL" to cr(
+    "sql expression use (@Cap (Row)()->Table)/SQL" to cr(
       "SELECT p.id, p.name, p.age, a.ownerId, a.street, a.city, r.ownerId, r.name, r.model FROM Person p INNER JOIN Address a ON p.id = a.ownerId INNER JOIN Robot r ON p.id = r.ownerId"
     ),
-    "capture (@Cap (Row)()->Table)/XR" to kt(
+    "sql (@Cap (Row)()->Table)/XR" to kt(
       "select { val p = from(Table(Person)); val a = from({ this -> Table(Address).join { a -> this.id == a.ownerId } }.toQuery.apply(p)); val r = from({ this -> Table(Robot).join { r -> this.id == r.ownerId } }.toQuery.apply(p)); Triple(first = p, second = a, third = r) }"
     ),
-    "capture (@Cap (Row)()->Table)/SQL" to cr(
+    "sql (@Cap (Row)()->Table)/SQL" to cr(
       "SELECT p.id, p.name, p.age, a.ownerId, a.street, a.city, r.ownerId, r.name, r.model FROM Person p INNER JOIN Address a ON p.id = a.ownerId INNER JOIN Robot r ON p.id = r.ownerId"
     ),
   )

--- a/testing/src/commonTest/kotlin/io/exoquery/NameEscapeSpec.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/NameEscapeSpec.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 class NameEscapeSpec: GoldenSpecDynamic(NameEscapeSpecGoldenDynamic, Mode.ExoGoldenTest(), {
 
@@ -8,7 +8,7 @@ class NameEscapeSpec: GoldenSpecDynamic(NameEscapeSpecGoldenDynamic, Mode.ExoGol
   "keyword-escaping should work property for" - {
     "table names" {
       data class user(val id: Int, val name: String)
-      val q = capture.select {
+      val q = sql.select {
         val t = from(Table<user>())
         where { t.id == 123 }
         t
@@ -18,7 +18,7 @@ class NameEscapeSpec: GoldenSpecDynamic(NameEscapeSpecGoldenDynamic, Mode.ExoGol
     }
     "table variable names" {
       data class MyTable(val id: Int, val name: String)
-      val q = capture.select {
+      val q = sql.select {
         val user = from(Table<MyTable>())
         where { user.id == 123 }
         user
@@ -28,7 +28,7 @@ class NameEscapeSpec: GoldenSpecDynamic(NameEscapeSpecGoldenDynamic, Mode.ExoGol
     }
     "column names" {
       data class MyTable(val id: Int, val user: String)
-      val q = capture.select {
+      val q = sql.select {
         val t = from(Table<MyTable>())
         where { t.id == 123 }
         t.user
@@ -39,8 +39,8 @@ class NameEscapeSpec: GoldenSpecDynamic(NameEscapeSpecGoldenDynamic, Mode.ExoGol
     "column names in a subquery" {
       data class MyTable(val id: Int, val user: String)
       data class MySubTable(val user: MyTable, val id: Int)
-      val q = capture.select {
-        val t = from(capture.select {
+      val q = sql.select {
+        val t = from(sql.select {
           val tt = from(Table<MyTable>())
           where { tt.id == 123 }
           MySubTable(tt, tt.id)

--- a/testing/src/commonTest/kotlin/io/exoquery/NamingAnnotationActionReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/NamingAnnotationActionReq.kt
@@ -2,35 +2,35 @@ package io.exoquery
 
 import io.exoquery.annotation.ExoEntity
 import io.exoquery.annotation.ExoField
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 class NamingAnnotationActionReq: GoldenSpecDynamic(NamingAnnotationActionReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "action with rename" - {
     @ExoEntity("PERSON") data class Person(@ExoField("ID") val id: Int, @ExoField("NAME") val name: String, val age: Int)
 
     "should work (and quote) in insert" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to "Joe", age to 123) }.returning { p -> p.id to p.name }
       }.dyanmic()
       shouldBeGolden(q.build<PostgresDialect>())
     }
 
     "should work (and quote) in insert using self column" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to name + "_Suffix", age to 123) }.returning { p -> p.id to p.name }
       }.dyanmic()
       shouldBeGolden(q.build<PostgresDialect>())
     }
 
     "should work (and quote) in insert using self column with onConflict ignore" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to "Joe", age to 123).onConflictIgnore(id) }
       }
       shouldBeGolden(q.build<PostgresDialect>())
     }
 
     "should work (and quote) in insert using self column with onConflict update" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name to "Joe", age to 123).onConflictUpdate(id) { excl -> set(name to excl.name + "_Suffix") } }
       }
       shouldBeGolden(q.build<PostgresDialect>())
@@ -43,28 +43,28 @@ class NamingAnnotationActionReq: GoldenSpecDynamic(NamingAnnotationActionReqGold
     data class Person(@ExoField("ID") val id: Int, val name: Name, val age: Int)
 
     "should work (and quote) in insert" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name.first to "Joe", age to 123) }.returning { p -> p.id to p.name }
       }.dyanmic()
       shouldBeGolden(q.build<PostgresDialect>())
     }
 
     "should work (and quote) in insert using self column" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name.first to name.first + "_Suffix", age to 123) }.returning { p -> p.id to p.name }
       }.dyanmic()
       shouldBeGolden(q.build<PostgresDialect>())
     }
 
     "should work (and quote) in insert using self column with onConflict ignore" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name.first to "Joe", age to 123).onConflictIgnore(name.first) }
       }
       shouldBeGolden(q.build<PostgresDialect>())
     }
 
     "should work (and quote) in insert using self column with onConflict update" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name.first to "Joe", age to 123).onConflictUpdate(id) { excl -> set(name.first to excl.name.first + "_Suffix") } }
       }
       shouldBeGolden(q.build<PostgresDialect>())
@@ -76,28 +76,28 @@ class NamingAnnotationActionReq: GoldenSpecDynamic(NamingAnnotationActionReqGold
     @ExoEntity("PERSON") data class Person(@ExoField("ID") val id: Int, @ExoField("NAME") val name: Name, val age: Int)
 
     "should work (and quote) in insert" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name.first to "Joe", age to 123) }.returning { p -> p.id to p.name }
       }.dyanmic()
       shouldBeGolden(q.build<PostgresDialect>())
     }
 
     "should work (and quote) in insert using self column" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name.first to name.first + "_Suffix", age to 123) }.returning { p -> p.id to p.name }
       }.dyanmic()
       shouldBeGolden(q.build<PostgresDialect>())
     }
 
     "should work (and quote) in insert using self column with onConflict ignore" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name.first to "Joe", age to 123).onConflictIgnore(name.first) }
       }
       shouldBeGolden(q.build<PostgresDialect>())
     }
 
     "should work (and quote) in insert using self column with onConflict update" {
-      val q = capture {
+      val q = sql {
         insert<Person> { set(name.first to "Joe", age to 123).onConflictUpdate(id) { excl -> set(name.first to excl.name.first + "_Suffix") } }
       }
       shouldBeGolden(q.build<PostgresDialect>())

--- a/testing/src/commonTest/kotlin/io/exoquery/NamingAnnotationReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/NamingAnnotationReq.kt
@@ -19,7 +19,7 @@ class NamingAnnotationReq: GoldenSpecDynamic(NamingAnnotationReqGoldenDynamic, M
     )
 
     "no apply quotes in postgres if all lower-case" {
-      val query = capture {
+      val query = sql {
         Table<PersonAnnotated>().filter { it.firstName == "Joe" && it.lastName == "Bloggs" }
       }
       shouldBeGolden(query.xr, "XR")
@@ -27,7 +27,7 @@ class NamingAnnotationReq: GoldenSpecDynamic(NamingAnnotationReqGoldenDynamic, M
     }
 
     "apply quotes in generic DBs if all lower-case" {
-      val query = capture {
+      val query = sql {
         Table<PersonAnnotated>().filter { it.firstName == "Joe" && it.lastName == "Bloggs" }
       }
       shouldBeGolden(query.xr, "XR")
@@ -61,14 +61,14 @@ class NamingAnnotationReq: GoldenSpecDynamic(NamingAnnotationReqGoldenDynamic, M
     )
 
     "in a query" {
-      val query = capture {
+      val query = sql {
         Table<PersonAnnotated>().filter { it.firstName == "Joe" && it.lastName == "Bloggs" }
       }
       shouldBeGolden(query.xr, "XR")
       shouldBeGolden(query.buildFor.Postgres(), "SQL")
     }
     "in a query - with overrides" {
-      val query = capture {
+      val query = sql {
         Table<PersonAnnotatedOverride>().filter { it.firstName == "Joe" && it.lastName == "Bloggs" }
       }
       shouldBeGolden(query.xr, "XR")
@@ -76,14 +76,14 @@ class NamingAnnotationReq: GoldenSpecDynamic(NamingAnnotationReqGoldenDynamic, M
     }
 
     "in an action" {
-      val action = capture {
+      val action = sql {
         insert<PersonAnnotated> { set(firstName to "Joe", lastName to "Bloggs", age to 42) }
       }
       shouldBeGolden(action.xr, "XR")
       shouldBeGolden(action.buildFor.Postgres(), "SQL")
     }
     "in an action - with overrides" {
-      val action = capture {
+      val action = sql {
         insert<PersonAnnotatedOverride> { set(firstName to "Joe", lastName to "Bloggs", age to 42) }
       }
       shouldBeGolden(action.xr, "XR")
@@ -91,14 +91,14 @@ class NamingAnnotationReq: GoldenSpecDynamic(NamingAnnotationReqGoldenDynamic, M
     }
 
     "in an action with setParams" {
-      val action = capture {
+      val action = sql {
         insert<PersonAnnotated> { setParams(PersonAnnotated("Joe", "Bloggs", 42)) }
       }
       shouldBeGolden(action.determinizeDynamics().xr, "XR")
       shouldBeGolden(action.buildFor.Postgres().determinizeDynamics(), "SQL")
     }
     "in an action with setParams - with overrides" {
-      val action = capture {
+      val action = sql {
         insert<PersonAnnotatedOverride> { setParams(PersonAnnotatedOverride("Joe", "Bloggs", 42)) }
       }
       shouldBeGolden(action.determinizeDynamics().xr, "XR")

--- a/testing/src/commonTest/kotlin/io/exoquery/ParamReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ParamReq.kt
@@ -1,12 +1,12 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Person
 
 class ParamReq: GoldenSpecDynamic(ParamReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "single single-param" - {
     val n = "Leah"
-    val cap = capture { Table<Person>().filter { p -> p.name == param(n) } }
+    val cap = sql { Table<Person>().filter { p -> p.name == param(n) } }
     val build = cap.build<PostgresDialect>()
     "compileTime" {
       shouldBeGolden(build.value, "Original SQL")
@@ -23,7 +23,7 @@ class ParamReq: GoldenSpecDynamic(ParamReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "multi single-param" - {
     val n = "Leib"
     val a = 42
-    val cap = capture { Table<Person>().filter { p -> p.name == param(n) && p.age == param(a) } }
+    val cap = sql { Table<Person>().filter { p -> p.name == param(n) && p.age == param(a) } }
     val build = cap.build<PostgresDialect>()
     "compileTime" {
       shouldBeGolden(build.value, "Original SQL")
@@ -40,7 +40,7 @@ class ParamReq: GoldenSpecDynamic(ParamReqGoldenDynamic, Mode.ExoGoldenTest(), {
 
   "single multi-param" - {
     val names = listOf("Leah", "Leib")
-    val cap = capture { Table<Person>().filter { p -> p.name in params(names) } }
+    val cap = sql { Table<Person>().filter { p -> p.name in params(names) } }
     val build = cap.build<PostgresDialect>()
     "compileTime" {
       shouldBeGolden(build.value, "Original SQL")
@@ -58,7 +58,7 @@ class ParamReq: GoldenSpecDynamic(ParamReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "multi multi-param" - {
     val names = listOf("Leah", "Leib")
     val ages = listOf(42, 43)
-    val cap = capture { Table<Person>().filter { p -> p.name in params(names) && p.age in params(ages) } }
+    val cap = sql { Table<Person>().filter { p -> p.name in params(names) && p.age in params(ages) } }
     val build = cap.build<PostgresDialect>()
     "compileTime" {
       shouldBeGolden(build.value, "Original SQL")
@@ -76,7 +76,7 @@ class ParamReq: GoldenSpecDynamic(ParamReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "one single, one multi" - {
     val n = "Joe"
     val ages = listOf(42, 43)
-    val cap = capture { Table<Person>().filter { p -> p.name == param(n) && p.age in params(ages) } }
+    val cap = sql { Table<Person>().filter { p -> p.name == param(n) && p.age in params(ages) } }
     val build = cap.build<PostgresDialect>()
     "compileTime" {
       shouldBeGolden(build.value, "Original SQL")
@@ -95,7 +95,7 @@ class ParamReq: GoldenSpecDynamic(ParamReqGoldenDynamic, Mode.ExoGoldenTest(), {
     "LocalDate comparison" {
       data class Client(val name: String, val birthDate: kotlinx.datetime.LocalDate)
       val test = kotlinx.datetime.LocalDate(2000, 1, 1)
-      val q = capture.select {
+      val q = sql.select {
         val c = from(Table<Client>())
         where { c.birthDate > param(test) || c.birthDate >= param(test) || c.birthDate < param(test) || c.birthDate <= param(test) }
         c.name
@@ -108,7 +108,7 @@ class ParamReq: GoldenSpecDynamic(ParamReqGoldenDynamic, Mode.ExoGoldenTest(), {
     "LocalTime comparison" {
       data class Client(val name: String, val birthTime: kotlinx.datetime.LocalTime)
       val test = kotlinx.datetime.LocalTime(12, 0, 0)
-      val q = capture.select {
+      val q = sql.select {
         val c = from(Table<Client>())
         where { c.birthTime > param(test) || c.birthTime >= param(test) || c.birthTime < param(test) || c.birthTime <= param(test) }
         c.name
@@ -121,7 +121,7 @@ class ParamReq: GoldenSpecDynamic(ParamReqGoldenDynamic, Mode.ExoGoldenTest(), {
     "LocalDateTime comparison" {
       data class Client(val name: String, val birthDateTime: kotlinx.datetime.LocalDateTime)
       val test = kotlinx.datetime.LocalDateTime(2000, 1, 1, 12, 0, 0)
-      val q = capture.select {
+      val q = sql.select {
         val c = from(Table<Client>())
         where { c.birthDateTime > param(test) || c.birthDateTime >= param(test) || c.birthDateTime < param(test) || c.birthDateTime <= param(test) }
         c.name
@@ -134,7 +134,7 @@ class ParamReq: GoldenSpecDynamic(ParamReqGoldenDynamic, Mode.ExoGoldenTest(), {
     "Instant comparison" {
       data class Client(val name: String, val birthInstant: kotlinx.datetime.Instant)
       val test = kotlinx.datetime.Instant.fromEpochSeconds(946684800) // 2000-01-01T00:00:00Z
-      val q = capture.select {
+      val q = sql.select {
         val c = from(Table<Client>())
         where { c.birthInstant > param(test) || c.birthInstant >= param(test) || c.birthInstant < param(test) || c.birthInstant <= param(test) }
         c.name

--- a/testing/src/commonTest/kotlin/io/exoquery/ParamSpec.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ParamSpec.kt
@@ -2,8 +2,8 @@
 //
 //import io.exoquery.serial.ParamSerializer
 //import io.exoquery.serial.contextualSerializer
-//import io.exoquery.sql.PostgresDialect
-//import io.exoquery.sql.Renderer
+//import io.exoquery.PostgresDialect
+//import io.exoquery.lang.Renderer
 //import io.exoquery.testdata.Person
 //import io.exoquery.testdata.pIdent
 //import io.exoquery.testdata.personEnt
@@ -24,7 +24,7 @@
 //  "fullQuery" - {
 //    "param" {
 //      // TODO need to also test dynamic-path of this
-//      val cap = capture { Table<Person>().filter { p -> p.name == param("name") } }
+//      val cap = sql { Table<Person>().filter { p -> p.name == param("name") } }
 //      cap.determinizeDynamics() shouldBe SqlQuery(
 //        XR.Filter(personEnt, pIdent, XR.BinaryOp(XR.Property(pIdent, "name"), OP.EqEq, XR.TagForParam.valueTag("0"))),
 //        RuntimeSet.Empty,
@@ -57,7 +57,7 @@
 //    "params" {
 //      // TODO need to also test dynamic-path of this
 //      val cap =
-//        capture { Table<Person>().filter { p -> p.name in params(listOf("name1", "name2")) } }.determinizeDynamics()
+//        sql { Table<Person>().filter { p -> p.name in params(listOf("name1", "name2")) } }.determinizeDynamics()
 //      cap shouldBe SqlQuery(
 //        // It should be a standard filter but the `in` should be rendered as a list.contains(value) XR.MethodCall instances
 //        XR.Filter(
@@ -103,14 +103,14 @@
 //  }
 //  "param" - {
 //    "string" {
-//      capture.expression { param("name") }.determinizeDynamics() shouldBe SqlExpression(
+//      sql.expression { param("name") }.determinizeDynamics() shouldBe SqlExpression(
 //        XR.TagForParam.valueTag("0"),
 //        RuntimeSet.Empty,
 //        ParamSet(listOf(ParamSingle(BID("0"), "name", ParamSerializer.String)))
 //      )
 //    }
 //    "int" {
-//      capture.expression { param(123) }.determinizeDynamics() shouldBe SqlExpression(
+//      sql.expression { param(123) }.determinizeDynamics() shouldBe SqlExpression(
 //        XR.TagForParam.valueTag("0"),
 //        RuntimeSet.Empty,
 //        ParamSet(listOf(ParamSingle(BID("0"), 123, ParamSerializer.Int)))
@@ -127,7 +127,7 @@
 //
 //  "paramCtx" - {
 //    "date" {
-//      val cap = capture.expression { paramCtx(date) }
+//      val cap = sql.expression { paramCtx(date) }
 //      cap.xr.type shouldBe XRType.Value
 //      cap.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
 //        XR.TagForParam.valueTag("0"),
@@ -136,7 +136,7 @@
 //      ).withNonStrictEquality()
 //    }
 //    "myCustomDate" {
-//      val cap = capture.expression { paramCtx(myDate) }
+//      val cap = sql.expression { paramCtx(myDate) }
 //      cap.xr.type shouldBe XRType.Value
 //      cap.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
 //        XR.TagForParam.valueTag("0"),
@@ -148,7 +148,7 @@
 //
 //  "paramCustom" - {
 //    "date" {
-//      val cap = capture.expression { paramCustom(date, ContextualSerializer(LocalDate::class)) }
+//      val cap = sql.expression { paramCustom(date, ContextualSerializer(LocalDate::class)) }
 //      cap.xr.type shouldBe XRType.Value
 //      cap.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
 //        XR.TagForParam.valueTag("0"),
@@ -157,7 +157,7 @@
 //      ).withNonStrictEquality()
 //    }
 //    "myCustomDate" {
-//      val cap = capture.expression { paramCustom(myDate, ContextualSerializer(MyCustomDate::class)) }
+//      val cap = sql.expression { paramCustom(myDate, ContextualSerializer(MyCustomDate::class)) }
 //      cap.xr.type shouldBe XRType.Value
 //      cap.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
 //        XR.TagForParam.valueTag("0"),
@@ -170,7 +170,7 @@
 //  "paramCustomValue" - {
 //    "date" {
 //      val v = ValueWithSerializer.invoke(date, ContextualSerializer(LocalDate::class))
-//      val cap = capture.expression { param(v) }
+//      val cap = sql.expression { param(v) }
 //      cap.xr.type shouldBe XRType.Value
 //      cap.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
 //        XR.TagForParam.valueTag("0"),
@@ -180,7 +180,7 @@
 //    }
 //    "myDate" {
 //      val v = ValueWithSerializer.invoke(myDate, ContextualSerializer(MyCustomDate::class))
-//      capture.expression { param(v) }.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
+//      sql.expression { param(v) }.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
 //        XR.TagForParam.valueTag("0"),
 //        RuntimeSet.Empty,
 //        ParamSet(listOf(ParamSingle(BID("0"), myDate, contextualSerializer<MyCustomDate>())))
@@ -190,7 +190,7 @@
 //
 //  "params" {
 //    val myList = listOf(1, 2, 3)
-//    val cap = capture.expression { params(myList) }
+//    val cap = sql.expression { params(myList) }
 //    cap.xr.type shouldBe XRType.Value
 //    cap.determinizeDynamics() shouldBe SqlExpression(
 //      XR.TagForParam.valueTag("0"),
@@ -202,7 +202,7 @@
 //  "paramsCustom" - {
 //    "date" {
 //      val myList = listOf(date, date)
-//      val cap = capture.expression { paramsCustom(myList, ContextualSerializer(LocalDate::class)) }
+//      val cap = sql.expression { paramsCustom(myList, ContextualSerializer(LocalDate::class)) }
 //      cap.xr.type shouldBe XRType.Value
 //      cap.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
 //        XR.TagForParam.valueTag("0"),
@@ -212,7 +212,7 @@
 //    }
 //    "myCustomDate" {
 //      val myList = listOf(myDate, myDate)
-//      val cap = capture.expression { paramsCustom(myList, ContextualSerializer(MyCustomDate::class)) }
+//      val cap = sql.expression { paramsCustom(myList, ContextualSerializer(MyCustomDate::class)) }
 //      cap.xr.type shouldBe XRType.Value
 //      cap.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
 //        XR.TagForParam.valueTag("0"),
@@ -226,7 +226,7 @@
 //    "date" {
 //      val myList = listOf(date, date)
 //      val v = ValuesWithSerializer.invoke(myList, ContextualSerializer(LocalDate::class))
-//      val cap = capture.expression { params(v) }
+//      val cap = sql.expression { params(v) }
 //      cap.xr.type shouldBe XRType.Value
 //      cap.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
 //        XR.TagForParam.valueTag("0"),
@@ -237,7 +237,7 @@
 //    "myCustomDate" {
 //      val myList = listOf(myDate, myDate)
 //      val v = ValuesWithSerializer.invoke(myList, ContextualSerializer(MyCustomDate::class))
-//      val cap = capture.expression { params(v) }
+//      val cap = sql.expression { params(v) }
 //      cap.xr.type shouldBe XRType.Value
 //      cap.determinizeDynamics().withNonStrictEquality() shouldBe SqlExpression<LocalDate>(
 //        XR.TagForParam.valueTag("0"),

--- a/testing/src/commonTest/kotlin/io/exoquery/QueryAdvancedReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/QueryAdvancedReq.kt
@@ -2,7 +2,7 @@
 
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Address
 import io.exoquery.testdata.Person
 import io.exoquery.testdata.Robot
@@ -16,7 +16,7 @@ class QueryAdvancedReq: GoldenSpec(QueryAdvancedReqGolden, {
   // TODO implement and test deconstruction e.g. val (p, a) = from(Table<PersonToAddress>())
   "select clause + join + nested filters" {
     val people =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>().filter { p -> p.age > 18 })
         val a = join(Table<Address>().filter { a -> a.street == "123 St." }) { a -> a.ownerId == p.id }
         p to a
@@ -25,9 +25,9 @@ class QueryAdvancedReq: GoldenSpec(QueryAdvancedReqGolden, {
   }
   "select clauses from(nested)" {
     val people =
-      capture.select {
+      sql.select {
         val pa = from(
-          capture.select {
+          sql.select {
             val p = from(Table<Person>())
             val a = join(Table<Address>()) { a -> a.ownerId == p.id }
             p to a
@@ -40,10 +40,10 @@ class QueryAdvancedReq: GoldenSpec(QueryAdvancedReqGolden, {
   }
   "select clauses with join(select-clause)" {
     val people =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>())
         val ar = join(
-          capture.select {
+          sql.select {
             val a = from(Table<Address>())
             val r = join(Table<Robot>()) { r -> r.ownerId == p.id && r.ownerId == a.ownerId }
             a to r
@@ -56,16 +56,16 @@ class QueryAdvancedReq: GoldenSpec(QueryAdvancedReqGolden, {
   "select clauses from(select-clause) + join(select-clause)" {
     // select from(person(name == "Joe").join(robot)), join(person(name == "Jim").join(address))
     val people =
-      capture.select {
+      sql.select {
         val pr = from(
-          capture.select {
+          sql.select {
             val p = from(Table<Person>().filter { p -> p.name == "Joe" })
             val r = join(Table<Robot>()) { r -> r.ownerId == p.id }
             p to r
           }
         )
         val pa = join(
-          capture.select {
+          sql.select {
             val p = from(Table<Person>().filter { p -> p.name == "Jim" })
             val a = join(Table<Address>()) { a -> a.ownerId == p.id }
             p to a
@@ -77,49 +77,49 @@ class QueryAdvancedReq: GoldenSpec(QueryAdvancedReqGolden, {
   }
   "select clauses from(person.map(Robot)) + join" {
     val people =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>().map { p -> Robot(p.id, p.name, p.name) })
         val r = join(Table<Address>()) { a -> a.ownerId == p.ownerId }
         p to r
       }
     people.buildPretty<PostgresDialect>("select clauses from(person.map(Robot)) + join").shouldBeGolden()
   }
-  "select clauses join(capture+map)" {
+  "select clauses join(sql+map)" {
     val people =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>())
-        val r = join(capture { Table<Robot>().map { r -> r.ownerId } }) { r -> r == p.id }
+        val r = join(sql { Table<Robot>().map { r -> r.ownerId } }) { r -> r == p.id }
         p to r
       }
-    people.buildPretty<PostgresDialect>("select clauses join(capture+map)").shouldBeGolden()
+    people.buildPretty<PostgresDialect>("select clauses join(sql+map)").shouldBeGolden()
   }
-  "capture + select-clause + filters afterward" {
-    val people = capture {
+  "sql + select-clause + filters afterward" {
+    val people = sql {
       Table<Person>().flatMap { p ->
-        capture.select {
+        sql.select {
           val a = from(Table<Address>().filter { a -> a.ownerId == p.id })
           val r = join(Table<Robot>()) { r -> r.ownerId == p.id }
           Triple(p, a, r)
         }
       }
     }
-    people.buildPretty<PostgresDialect>("capture + select-clause + filters afterward").shouldBeGolden()
+    people.buildPretty<PostgresDialect>("sql + select-clause + filters afterward").shouldBeGolden()
   }
-  "capture + select-clause (+nested) + filters afterward" {
-    val people = capture {
+  "sql + select-clause (+nested) + filters afterward" {
+    val people = sql {
       Table<Person>().flatMap { p ->
-        capture.select {
+        sql.select {
           val a = from(Table<Address>().filter { a -> a.ownerId == p.id }.nested())
           val r = join(Table<Robot>()) { r -> r.ownerId == p.id }
           Triple(p, a, r)
         }
       }
     }
-    people.buildPretty<PostgresDialect>("capture + select-clause (+nested) + filters afterward").shouldBeGolden()
+    people.buildPretty<PostgresDialect>("sql + select-clause (+nested) + filters afterward").shouldBeGolden()
   }
   "multiple from-clauses - no filters" {
     val people =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>())
         val a = from(Table<Address>())
         p to a
@@ -128,7 +128,7 @@ class QueryAdvancedReq: GoldenSpec(QueryAdvancedReqGolden, {
   }
   "multiple from-clauses - filter on 2nd" {
     val people =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>())
         val a = from(Table<Address>().filter { a -> a.ownerId == p.id })
         p to a
@@ -137,7 +137,7 @@ class QueryAdvancedReq: GoldenSpec(QueryAdvancedReqGolden, {
   }
   "multiple from-clauses - filter on where" {
     val people =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>())
         val a = from(Table<Address>())
         where { p.id == a.ownerId }

--- a/testing/src/commonTest/kotlin/io/exoquery/QueryAdvancedReqGolden.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/QueryAdvancedReqGolden.kt
@@ -121,7 +121,7 @@ object QueryAdvancedReqGolden : GoldenQueryFile {
         INNER JOIN Address a ON a.ownerId = p.id
       """
     ),
-    "select clauses join(capture+map)" to cr(
+    "select clauses join(sql+map)" to cr(
       """
       SELECT
         p.id,
@@ -138,7 +138,7 @@ object QueryAdvancedReqGolden : GoldenQueryFile {
         ) AS r ON r.value = p.id
       """
     ),
-    "capture + select-clause + filters afterward" to cr(
+    "sql + select-clause + filters afterward" to cr(
       """
       SELECT
         p.id,
@@ -158,7 +158,7 @@ object QueryAdvancedReqGolden : GoldenQueryFile {
         a.ownerId = p.id
       """
     ),
-    "capture + select-clause (+nested) + filters afterward" to cr(
+    "sql + select-clause (+nested) + filters afterward" to cr(
       """
       SELECT
         p.id,

--- a/testing/src/commonTest/kotlin/io/exoquery/QueryDistinctReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/QueryDistinctReq.kt
@@ -1,27 +1,27 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Address
 import io.exoquery.testdata.Person
 
 class QueryDistinctReq: GoldenSpecDynamic(QueryDistinctReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "distinct simple" - {
     "table.map.distinct" {
-      val q = capture {
+      val q = sql {
         Table<Person>().map { it.name to it.age }.distinct()
       }
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "table.map.distinct.sortBy" {
-      val q = capture {
+      val q = sql {
         Table<Person>().map { it.name to it.age }.distinct().sortedBy { it.first }
       }
       shouldBeGolden(q.xr, "XR")
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "(selectClause + aggregation).distinct" {
-      val q = capture {
+      val q = sql {
         select {
           val p = from(Table<Person>())
           val a = join(Table<Address>()) { p.id == it.ownerId }
@@ -33,7 +33,7 @@ class QueryDistinctReq: GoldenSpecDynamic(QueryDistinctReqGoldenDynamic, Mode.Ex
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "table.join(table.distinct)" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         val a = join(Table<Address>().distinct()) { p.id == it.ownerId }
         p to a
@@ -42,7 +42,7 @@ class QueryDistinctReq: GoldenSpecDynamic(QueryDistinctReqGoldenDynamic, Mode.Ex
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "from.distinct, from" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>().distinct())
         val a = from(Table<Address>().filter { it.ownerId == p.id })
         p to a
@@ -51,7 +51,7 @@ class QueryDistinctReq: GoldenSpecDynamic(QueryDistinctReqGoldenDynamic, Mode.Ex
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "from.distinct, sort.join" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>().distinct())
         val a = join(Table<Address>().sortedBy { it.city }) { p.id == it.ownerId }
         p to a

--- a/testing/src/commonTest/kotlin/io/exoquery/QueryReqGoldenDynamic.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/QueryReqGoldenDynamic.kt
@@ -12,6 +12,12 @@ object QueryReqGoldenDynamic: GoldenQueryFile {
     "basic query" to cr(
       "SELECT x.id, x.name, x.age FROM Person x"
     ),
+    "basic query - deprecated capture/XR" to kt(
+      "Table(Person)"
+    ),
+    "basic query - deprecated capture" to cr(
+      "SELECT x.id, x.name, x.age FROM Person x"
+    ),
     "query with map/XR" to kt(
       "Table(Person).map { p -> p.name }"
     ),

--- a/testing/src/commonTest/kotlin/io/exoquery/QuerySpecCorrelated.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/QuerySpecCorrelated.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 // Note that the 1st time you overwrite the golden file it will still fail because the compile is using teh old version
 // Also note that it won't actually override the BasicQuerySanitySpecGolden file unless you change this one
@@ -13,14 +13,14 @@ class QuerySpecCorrelated : GoldenSpecDynamic(QuerySpecCorrelatedGoldenDynamic, 
 
   "query with co-releated in filter - isNotEmpty" {
     val people =
-      capture { Table<Person>().filter { p -> Table<Address>().filter { a -> a.ownerId == p.id }.isNotEmpty() } }
+      sql { Table<Person>().filter { p -> Table<Address>().filter { a -> a.ownerId == p.id }.isNotEmpty() } }
     shouldBeGolden(people.xr, "XR")
     shouldBeGolden(people.build<PostgresDialect>())
   }
 
   "query with co-releated in filter - isEmpty" {
     val people =
-      capture { Table<Person>().filter { p -> Table<Address>().filter { a -> a.ownerId == p.id }.isEmpty() } }
+      sql { Table<Person>().filter { p -> Table<Address>().filter { a -> a.ownerId == p.id }.isEmpty() } }
     shouldBeGolden(people.xr, "XR")
     shouldBeGolden(people.build<PostgresDialect>())
   }
@@ -28,7 +28,7 @@ class QuerySpecCorrelated : GoldenSpecDynamic(QuerySpecCorrelatedGoldenDynamic, 
   // Single-value expressions are not supported yet (i.e. this is the equlivalent of run-query-single)
   //"query aggregation - top-level" - {
   //  "min" {
-  //    val people = capture { Table<Address>().map { a -> a.ownerId }.min() }
+  //    val people = sql { Table<Address>().map { a -> a.ownerId }.min() }
   //    shouldBeGolden(people.xr, "XR")
   //    shouldBeGolden(people.buildRuntime(PostgresDialect(), "test"))
   //  }
@@ -36,7 +36,7 @@ class QuerySpecCorrelated : GoldenSpecDynamic(QuerySpecCorrelatedGoldenDynamic, 
 
   "query aggregation" - {
     "min" {
-      val people = capture { Table<Person>().filter { p -> Table<Address>().map { a -> a.ownerId }.min() == p.id } }
+      val people = sql { Table<Person>().filter { p -> Table<Address>().map { a -> a.ownerId }.min() == p.id } }
       shouldBeGolden(people.xr, "XR")
       shouldBeGolden(people.buildRuntime(PostgresDialect(), "test"))
     }
@@ -44,7 +44,7 @@ class QuerySpecCorrelated : GoldenSpecDynamic(QuerySpecCorrelatedGoldenDynamic, 
 
   "select aggregation" - {
     "min" {
-      val people = capture { Table<Address>().map { a -> min(a.ownerId) } }
+      val people = sql { Table<Address>().map { a -> min(a.ownerId) } }
       shouldBeGolden(people.xr, "XR")
       shouldBeGolden(people.build<PostgresDialect>())
     }

--- a/testing/src/commonTest/kotlin/io/exoquery/QueryValuePositionReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/QueryValuePositionReq.kt
@@ -6,11 +6,11 @@ import io.exoquery.testdata.Person
 class QueryValuePositionReq: GoldenSpecDynamic(QueryValuePositionReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "counting query + from + toValue" {
     val people =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>())
         Pair(
           p.name,
-          capture.select {
+          sql.select {
             val a = from(Table<Address>())
             where { a.street == "123 St." }
             count(a.ownerId)
@@ -21,7 +21,7 @@ class QueryValuePositionReq: GoldenSpecDynamic(QueryValuePositionReqGoldenDynami
     shouldBeGolden(people.buildFor.Postgres())
   }
   "select a constant" {
-    val one = capture.select { 1 }
+    val one = sql.select { 1 }
     shouldBeGolden(one.xr, "XR")
     shouldBeGolden(one.buildFor.Postgres())
   }

--- a/testing/src/commonTest/kotlin/io/exoquery/QueryWindowReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/QueryWindowReq.kt
@@ -1,12 +1,12 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 class QueryWindowReq: GoldenSpecDynamic(QueryWindowReqGoldenDynamic, Mode.ExoGoldenTest(), {
   data class Person(val id: Int, val name: String, val age: Int)
   "paritionBy, orderBy" - {
     "rank" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         Pair(
           p.name,
@@ -17,7 +17,7 @@ class QueryWindowReq: GoldenSpecDynamic(QueryWindowReqGoldenDynamic, Mode.ExoGol
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "avg" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         Pair(
           p.name,
@@ -28,7 +28,7 @@ class QueryWindowReq: GoldenSpecDynamic(QueryWindowReqGoldenDynamic, Mode.ExoGol
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "rowNumber" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         Pair(
           p.name,
@@ -39,7 +39,7 @@ class QueryWindowReq: GoldenSpecDynamic(QueryWindowReqGoldenDynamic, Mode.ExoGol
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "count" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         Pair(
           p.name,
@@ -50,7 +50,7 @@ class QueryWindowReq: GoldenSpecDynamic(QueryWindowReqGoldenDynamic, Mode.ExoGol
       shouldBeGolden(q.build<PostgresDialect>(), "SQL")
     }
     "count star" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         Pair(
           p.name,
@@ -63,7 +63,7 @@ class QueryWindowReq: GoldenSpecDynamic(QueryWindowReqGoldenDynamic, Mode.ExoGol
   }
   "just partitionBy" - {
     "rank" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         Pair(
           p.name,
@@ -76,7 +76,7 @@ class QueryWindowReq: GoldenSpecDynamic(QueryWindowReqGoldenDynamic, Mode.ExoGol
   }
   "just orderBy" - {
     "rank" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(Table<Person>())
         Pair(
           p.name,
@@ -88,7 +88,7 @@ class QueryWindowReq: GoldenSpecDynamic(QueryWindowReqGoldenDynamic, Mode.ExoGol
     }
   }
   "empty over" {
-    val q = capture.select {
+    val q = sql.select {
       val p = from(Table<Person>())
       Pair(
         p.name,

--- a/testing/src/commonTest/kotlin/io/exoquery/ReferenceReqBackward.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ReferenceReqBackward.kt
@@ -1,47 +1,47 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Person
 
 
 object ExampleBehindObject {
-  val people = capture { Table<Person>() }
+  val people = sql { Table<Person>() }
 }
 
 object ExampleBehindObjectNested {
-  val peopleNested = capture { Table<Person>() }
-  val people = capture { peopleNested }
+  val peopleNested = sql { Table<Person>() }
+  val people = sql { peopleNested }
 }
 
 object ExampleBehindObjectNested2x {
-  val people = capture {
+  val people = sql {
     ExampleBehindObjectNested.people.filter { p -> p.name == param("JoeJoe") }
   }
 }
 
 class ExampleBehindClass {
   val local = "Joe"
-  val people = capture { Table<Person>().filter { p -> p.name == param(local) } }
+  val people = sql { Table<Person>().filter { p -> p.name == param(local) } }
 }
 
 class ExampleBehindClassNested {
   val local = "Joe"
-  val peopleNested = capture { Table<Person>().filter { p -> p.name == param(local) } }
-  val people = capture { peopleNested }
+  val peopleNested = sql { Table<Person>().filter { p -> p.name == param(local) } }
+  val people = sql { peopleNested }
 }
 
 class ExampleBehindClassNested1 {
   val localA = "Joe"
   val localB = "Joe"
-  val peopleNested = capture { Table<Person>().filter { p -> p.name == param(localA) } }
-  val people = capture { peopleNested.filter { p -> p.name == param(localB) } }
+  val peopleNested = sql { Table<Person>().filter { p -> p.name == param(localA) } }
+  val people = sql { peopleNested.filter { p -> p.name == param(localB) } }
 }
 
 
 class ReferenceReqBackward: GoldenSpecDynamic(ReferenceReqBackwardGoldenDynamic, Mode.ExoGoldenTest(), {
   "in object" - {
     "using ahead object" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleBehindObject.people)
         p
       }
@@ -52,7 +52,7 @@ class ReferenceReqBackward: GoldenSpecDynamic(ReferenceReqBackwardGoldenDynamic,
     }
 
     "using ahead object with nested" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleBehindObjectNested.people)
         p
       }
@@ -63,7 +63,7 @@ class ReferenceReqBackward: GoldenSpecDynamic(ReferenceReqBackwardGoldenDynamic,
     }
 
     "using ahead object with nested 2x" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleBehindObjectNested2x.people)
         p
       }
@@ -76,7 +76,7 @@ class ReferenceReqBackward: GoldenSpecDynamic(ReferenceReqBackwardGoldenDynamic,
 
   "in class" - {
     "using ahead class" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleBehindClass().people)
         //ExampleCapObject.personName(p) to p.age
         p
@@ -88,7 +88,7 @@ class ReferenceReqBackward: GoldenSpecDynamic(ReferenceReqBackwardGoldenDynamic,
     }
 
     "using ahead class with nested" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleBehindClassNested().people)
         p
       }
@@ -99,7 +99,7 @@ class ReferenceReqBackward: GoldenSpecDynamic(ReferenceReqBackwardGoldenDynamic,
     }
 
     "using ahead class with nested 1" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleBehindClassNested1().people)
         p
       }

--- a/testing/src/commonTest/kotlin/io/exoquery/ReferenceReqForward.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ReferenceReqForward.kt
@@ -1,13 +1,13 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Person
 
 
 class ReferenceReqForward: GoldenSpecDynamic(ReferenceReqForwardGoldenDynamic, Mode.ExoGoldenTest(), {
   "in object" - {
     "using ahead object" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleAheadObject.people)
         p
       }
@@ -18,7 +18,7 @@ class ReferenceReqForward: GoldenSpecDynamic(ReferenceReqForwardGoldenDynamic, M
     }
 
     "using ahead object with nested" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleAheadObjectNested.people)
         p
       }
@@ -29,7 +29,7 @@ class ReferenceReqForward: GoldenSpecDynamic(ReferenceReqForwardGoldenDynamic, M
     }
 
     "using ahead object with nested 2x" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleAheadObjectNested2x.people)
         p
       }
@@ -40,7 +40,7 @@ class ReferenceReqForward: GoldenSpecDynamic(ReferenceReqForwardGoldenDynamic, M
     }
 
     "using ahead object with nested 3x" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleAheadObjectNested3x.people)
         p
       }
@@ -53,7 +53,7 @@ class ReferenceReqForward: GoldenSpecDynamic(ReferenceReqForwardGoldenDynamic, M
 
   "in class" - {
     "using ahead class" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleAheadClass().people)
         //ExampleCapObject.personName(p) to p.age
         p
@@ -65,7 +65,7 @@ class ReferenceReqForward: GoldenSpecDynamic(ReferenceReqForwardGoldenDynamic, M
     }
 
     "using ahead class with nested" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleAheadClassNested().people)
         p
       }
@@ -76,7 +76,7 @@ class ReferenceReqForward: GoldenSpecDynamic(ReferenceReqForwardGoldenDynamic, M
     }
 
     "using ahead class with nested 1" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(ExampleAheadClassNested1().people)
         p
       }
@@ -89,48 +89,48 @@ class ReferenceReqForward: GoldenSpecDynamic(ReferenceReqForwardGoldenDynamic, M
 })
 
 object ExampleAheadObjectNested3x {
-  val people = capture {
+  val people = sql {
     ExampleAheadObjectNested3xForward.people.filter { p -> p.name == param("JoeJoe") }
   }
 }
 
 object ExampleAheadObjectNested3xForward {
-  val people = capture { ExampleAheadObjectNested3xForwardForward.peopleNested }
+  val people = sql { ExampleAheadObjectNested3xForwardForward.peopleNested }
 }
 
 object ExampleAheadObjectNested3xForwardForward {
-  val peopleNested = capture { Table<Person>() }
+  val peopleNested = sql { Table<Person>() }
 }
 
 object ExampleAheadObject {
-  val people = capture { Table<Person>() }
+  val people = sql { Table<Person>() }
 }
 
 object ExampleAheadObjectNested {
-  val peopleNested = capture { Table<Person>() }
-  val people = capture { peopleNested }
+  val peopleNested = sql { Table<Person>() }
+  val people = sql { peopleNested }
 }
 
 object ExampleAheadObjectNested2x {
-  val people = capture {
+  val people = sql {
     ExampleAheadObjectNested.people.filter { p -> p.name == param("JoeJoe") }
   }
 }
 
 class ExampleAheadClass {
   val local = "Joe"
-  val people = capture { Table<Person>().filter { p -> p.name == param(local) } }
+  val people = sql { Table<Person>().filter { p -> p.name == param(local) } }
 }
 
 class ExampleAheadClassNested {
   val local = "Joe"
-  val peopleNested = capture { Table<Person>().filter { p -> p.name == param(local) } }
-  val people = capture { peopleNested }
+  val peopleNested = sql { Table<Person>().filter { p -> p.name == param(local) } }
+  val people = sql { peopleNested }
 }
 
 class ExampleAheadClassNested1 {
   val localA = "Joe"
   val localB = "Joe"
-  val peopleNested = capture { Table<Person>().filter { p -> p.name == param(localA) } }
-  val people = capture { peopleNested.filter { p -> p.name == param(localB) } }
+  val peopleNested = sql { Table<Person>().filter { p -> p.name == param(localA) } }
+  val people = sql { peopleNested.filter { p -> p.name == param(localB) } }
 }

--- a/testing/src/commonTest/kotlin/io/exoquery/ReferenceReqForwardCapturedFunction.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ReferenceReqForwardCapturedFunction.kt
@@ -1,14 +1,14 @@
 package io.exoquery
 
 import io.exoquery.annotation.CapturedFunction
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Person
 
 
 class ReferenceReqForwardCapturedFunction: GoldenSpecDynamic(ReferenceReqForwardCapturedFunctionGoldenDynamic, Mode.ExoGoldenTest(), {
   "in object" - {
     "using ahead object" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(CaptureAheadObject.people("Jack"))
         p
       }
@@ -19,7 +19,7 @@ class ReferenceReqForwardCapturedFunction: GoldenSpecDynamic(ReferenceReqForward
     }
 
     "using ahead object with nested" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(CaptureAheadObjectNested.people("Mack"))
         p
       }
@@ -30,7 +30,7 @@ class ReferenceReqForwardCapturedFunction: GoldenSpecDynamic(ReferenceReqForward
     }
 
     "using ahead object with nested 2x" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(CaptureAheadObjectNested2x.people("Abe"))
         p
       }
@@ -41,7 +41,7 @@ class ReferenceReqForwardCapturedFunction: GoldenSpecDynamic(ReferenceReqForward
     }
 
     "using ahead object with nested 3x" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(CaptureAheadObjectNested3x.people("JoeJoe"))
         p
       }
@@ -54,7 +54,7 @@ class ReferenceReqForwardCapturedFunction: GoldenSpecDynamic(ReferenceReqForward
 
   "in class" - {
     "using ahead class" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(CaptureAheadClass().people("Sam"))
         //CaptureCapObject.personName(p) to p.age
         p
@@ -66,7 +66,7 @@ class ReferenceReqForwardCapturedFunction: GoldenSpecDynamic(ReferenceReqForward
     }
 
     "using ahead class with nested" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(CaptureAheadClassNested().people("Sammy"))
         p
       }
@@ -77,7 +77,7 @@ class ReferenceReqForwardCapturedFunction: GoldenSpecDynamic(ReferenceReqForward
     }
 
     "using ahead class with nested 1" {
-      val q = capture.select {
+      val q = sql.select {
         val p = from(CaptureAheadClassNested1().people("Samson"))
         p
       }
@@ -92,37 +92,37 @@ class ReferenceReqForwardCapturedFunction: GoldenSpecDynamic(ReferenceReqForward
 
 object CaptureAheadObjectNested3x {
   @CapturedFunction
-  fun people(filter: String) = capture {
+  fun people(filter: String) = sql {
     CaptureAheadObjectNested3xForward.peopleNested(filter).filter { p -> p.name == param("JoeJoe") }
   }
 }
 
 object CaptureAheadObjectNested3xForward {
   @CapturedFunction
-  fun peopleNested(filter: String) = capture { CaptureAheadObjectNested3xForwardForward.peopleNestedNested(filter) }
+  fun peopleNested(filter: String) = sql { CaptureAheadObjectNested3xForwardForward.peopleNestedNested(filter) }
 }
 
 object CaptureAheadObjectNested3xForwardForward {
   @CapturedFunction
-  fun peopleNestedNested(filter: String) = capture { Table<Person>().filter { p -> p.name == filter } }
+  fun peopleNestedNested(filter: String) = sql { Table<Person>().filter { p -> p.name == filter } }
 }
 
 
 object CaptureAheadObject {
   @CapturedFunction
-  fun people(filter: String) = capture { Table<Person>().filter { p -> p.name == filter } }
+  fun people(filter: String) = sql { Table<Person>().filter { p -> p.name == filter } }
 }
 
 object CaptureAheadObjectNested {
   @CapturedFunction
-  fun peopleNested(filter: String) = capture { Table<Person>().filter { p -> p.name == filter } }
+  fun peopleNested(filter: String) = sql { Table<Person>().filter { p -> p.name == filter } }
   @CapturedFunction
-  fun people(filter: String) = capture { peopleNested(filter) }
+  fun people(filter: String) = sql { peopleNested(filter) }
 }
 
 object CaptureAheadObjectNested2x {
   @CapturedFunction
-  fun people(filter: String) = capture {
+  fun people(filter: String) = sql {
     CaptureAheadObjectNested.people(filter).filter { p -> p.name == param("JoeJoe") }
   }
 }
@@ -130,22 +130,22 @@ object CaptureAheadObjectNested2x {
 class CaptureAheadClass {
   val local = "Joe1"
   @CapturedFunction
-  fun people(filter: String) = capture { Table<Person>().filter { p -> p.name == param(local) && p.name == filter } }
+  fun people(filter: String) = sql { Table<Person>().filter { p -> p.name == param(local) && p.name == filter } }
 }
 
 class CaptureAheadClassNested {
   val local = "Joe2"
   @CapturedFunction
-  fun peopleNested(filter: String) = capture { Table<Person>().filter { p -> p.name == param(local) && p.name == filter } }
+  fun peopleNested(filter: String) = sql { Table<Person>().filter { p -> p.name == param(local) && p.name == filter } }
   @CapturedFunction
-  fun people(filter: String) = capture { peopleNested(filter) }
+  fun people(filter: String) = sql { peopleNested(filter) }
 }
 
 class CaptureAheadClassNested1 {
   val localA = "JoeA3"
   val localB = "JoeB3"
   @CapturedFunction
-  fun peopleNested(filter: String) = capture { Table<Person>().filter { p -> p.name == param(localA) || p.name == filter } }
+  fun peopleNested(filter: String) = sql { Table<Person>().filter { p -> p.name == param(localA) || p.name == filter } }
   @CapturedFunction
-  fun people(filter: String) = capture { peopleNested(filter).filter { p -> p.name == param(localB) && p.name == filter } }
+  fun people(filter: String) = sql { peopleNested(filter).filter { p -> p.name == param(localB) && p.name == filter } }
 }

--- a/testing/src/commonTest/kotlin/io/exoquery/SelectClauseQueryReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/SelectClauseQueryReq.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Address
 import io.exoquery.testdata.Person
 
@@ -13,7 +13,7 @@ class SelectClauseQueryReq : GoldenSpecDynamic(SelectClauseQueryReqGoldenDynamic
 
     "join(p.name?.first)" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(Table<Person>())
           val r = join(Table<Robot>()) { r -> p.name?.first == r.ownerFirstName }
           p to r
@@ -23,7 +23,7 @@ class SelectClauseQueryReq : GoldenSpecDynamic(SelectClauseQueryReqGoldenDynamic
     }
     "join(p.name?.first ?: alternative)" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(Table<Person>())
           val r = join(Table<Robot>()) { r -> p.name?.first ?: "defaultName" == r.ownerFirstName }
           p to r
@@ -33,7 +33,7 @@ class SelectClauseQueryReq : GoldenSpecDynamic(SelectClauseQueryReqGoldenDynamic
     }
     "joinLeft(p.name?.first ?: alternative)" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(Table<Person>())
           val r = joinLeft(Table<Robot>()) { r -> p.name?.first ?: "defaultName" == r.ownerFirstName }
           p.name to r?.model
@@ -44,7 +44,7 @@ class SelectClauseQueryReq : GoldenSpecDynamic(SelectClauseQueryReqGoldenDynamic
 
     "joinLeft(p.name?.first ?: alternative) -> r ?: alternative" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(Table<Person>())
           val r = joinLeft(Table<Robot>()) { r -> p.name?.first ?: "defaultName" == r.ownerFirstName }
           // TODO need an unhappy-paths test for this
@@ -58,7 +58,7 @@ class SelectClauseQueryReq : GoldenSpecDynamic(SelectClauseQueryReqGoldenDynamic
 
     "joinLeft(p.name?.first ?: alternative) -> p ?: alternative" {
       val people =
-        capture.select {
+        sql.select {
           val r = from(Table<Robot>())
           val p = joinLeft(Table<Person>()) { p -> r.ownerFirstName == (p.name?.first ?: "defaultName") }
           // TODO need an unhappy-paths test for this
@@ -71,7 +71,7 @@ class SelectClauseQueryReq : GoldenSpecDynamic(SelectClauseQueryReqGoldenDynamic
 
     "join + aggregation" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(Table<Person>())
           val r = join(Table<Robot>()) { r -> p.name?.first == r.ownerFirstName }
           groupBy(p.name?.first, r.model)
@@ -83,7 +83,7 @@ class SelectClauseQueryReq : GoldenSpecDynamic(SelectClauseQueryReqGoldenDynamic
 
     "sortBy" {
       val people =
-        capture.select {
+        sql.select {
           val p = from(Table<Person>())
           sortBy(p.age to Ord.Asc, p.name?.first to Ord.Desc)
           // TODO when I have the ability to test compile-errors, should test the error that happnes when I try doing p.name for the order-by expression
@@ -97,7 +97,7 @@ class SelectClauseQueryReq : GoldenSpecDynamic(SelectClauseQueryReqGoldenDynamic
 
   "join + where + groupBy + sortBy" {
     val people =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>())
         val a = join(Table<Address>()) { a -> p.id == a.ownerId }
         where { p.age > 18 }

--- a/testing/src/commonTest/kotlin/io/exoquery/SqlUdfReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/SqlUdfReq.kt
@@ -1,12 +1,12 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Address
 import io.exoquery.testdata.Person
 
 class SqlUdfReq: GoldenSpecDynamic(SqlUdfReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "does necessary casts" {
-    val q = capture {
+    val q = sql {
       Table<Person>().map { p -> p.age.toString() to p.name.toInt() }
     }.dyanmic()
     shouldBeGolden(q.xr, "XR")
@@ -15,7 +15,7 @@ class SqlUdfReq: GoldenSpecDynamic(SqlUdfReqGoldenDynamic, Mode.ExoGoldenTest(),
   "can handle de-nulling - element" {
     data class Test(val id: Int, val name: String?)
 
-    val q = capture {
+    val q = sql {
       Table<Test>().map { p -> p.name!! }
     }.dyanmic()
     shouldBeGolden(q.xr, "XR")
@@ -25,7 +25,7 @@ class SqlUdfReq: GoldenSpecDynamic(SqlUdfReqGoldenDynamic, Mode.ExoGoldenTest(),
     data class Test(val id: Int, val name: String?)
 
     val q =
-      capture.select {
+      sql.select {
         val p = from(Table<Person>())
         val a = joinLeft(Table<Address>()) { a -> a.ownerId == p.id }
         p.name to a!!.city

--- a/testing/src/commonTest/kotlin/io/exoquery/VariableReductionAdvancedReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/VariableReductionAdvancedReq.kt
@@ -2,7 +2,7 @@
 
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Address
 import io.exoquery.testdata.Person
 import io.exoquery.testdata.Robot
@@ -12,7 +12,7 @@ class VariableReductionAdvancedReq : GoldenSpec(VariableReductionAdvancedReqGold
     "in simple case" {
       data class Output(val name: String, val city: String)
 
-      val people = capture.select {
+      val people = sql.select {
         val (p, a) = from(
           select {
             val p = from(Table<Person>())
@@ -27,7 +27,7 @@ class VariableReductionAdvancedReq : GoldenSpec(VariableReductionAdvancedReqGold
 
     "with leaf-level props" {
 
-      val people = capture.select {
+      val people = sql.select {
         val (n, a) = from(
           select {
             val (id, name, age) = from(Table<Person>())
@@ -43,7 +43,7 @@ class VariableReductionAdvancedReq : GoldenSpec(VariableReductionAdvancedReqGold
     "when passed to further join" {
       data class Output(val name: String, val city: String, val robotName: String)
 
-      val people = capture.select {
+      val people = sql.select {
         val (p, a) = from(
           select {
             val p = from(Table<Person>())

--- a/testing/src/commonTest/kotlin/io/exoquery/VariableReductionReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/VariableReductionReq.kt
@@ -1,12 +1,12 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 import io.exoquery.testdata.Address
 import io.exoquery.testdata.Person
 
 class VariableReductionReq : GoldenSpecDynamic(VariableReductionReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "using it-variable should reduce to the letter `a` on the other side of the clause" {
-    val people = capture.select {
+    val people = sql.select {
       val p = from(Table<Person>())
       val a = join(Table<Address>()) { p.id == it.ownerId }
       p to a
@@ -16,24 +16,24 @@ class VariableReductionReq : GoldenSpecDynamic(VariableReductionReqGoldenDynamic
   }
 
   "node-level deconstruction shuold work" - {
-    val q = capture { Table<Pair<Person, Address>>().map { (p, a) -> p.name to a.street } }
+    val q = sql { Table<Pair<Person, Address>>().map { (p, a) -> p.name to a.street } }
     shouldBeGolden(q.xr, "XR")
     shouldBeGolden(q.build<PostgresDialect>(), "SQL")
   }
 
   "leaf-level deconstruction should work" - {
     "in map - single" {
-      val names = capture { Table<Person>().map { (id, name, age) -> name } }
+      val names = sql { Table<Person>().map { (id, name, age) -> name } }
       shouldBeGolden(names.xr, "XR")
       shouldBeGolden(names.build<PostgresDialect>(), "SQL")
     }
     "in map - multi" {
-      val names = capture { Table<Person>().map { (id, name, age) -> name to age } }
+      val names = sql { Table<Person>().map { (id, name, age) -> name to age } }
       shouldBeGolden(names.xr, "XR")
       shouldBeGolden(names.build<PostgresDialect>(), "SQL")
     }
     "in filter" {
-      val names = capture { Table<Person>().filter { (id, name, age) -> name == "Joe" } }
+      val names = sql { Table<Person>().filter { (id, name, age) -> name == "Joe" } }
       shouldBeGolden(names.xr, "XR")
       shouldBeGolden(names.build<PostgresDialect>(), "SQL")
     }

--- a/testing/src/commonTest/kotlin/io/exoquery/testdata/TestData.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/testdata/TestData.kt
@@ -1,6 +1,6 @@
 package io.exoquery.testdata
 
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.xr.XR
 import io.exoquery.xr.XRType
 
@@ -9,7 +9,7 @@ data class PersonNullable(val id: Int, val name: String?, val age: Int?)
 data class Address(val ownerId: Int, val street: String, val city: String)
 data class Robot(val ownerId: Int, val name: String, val model: String)
 
-val joes = capture { Table<Person>().filter { p -> p.name == "Joe" } }
+val joes = sql { Table<Person>().filter { p -> p.name == "Joe" } }
 val personTpe = XRType.Product("Person", listOf("id" to XRType.Value, "name" to XRType.Value, "age" to XRType.Value))
 val addressTpe =
   XRType.Product("Address", listOf("ownerId" to XRType.Value, "street" to XRType.Value, "city" to XRType.Value))

--- a/testing/src/jvmMain/kotlin/io/exoquery/AbstractionStuff.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/AbstractionStuff.kt
@@ -11,12 +11,12 @@ package io.exoquery
 //fun main() {
 //  @CapturedFunction
 //  fun <T: HasId> myFunction(input: SqlQuery<T>, selector: (T) -> String) =
-//    capture.select {
+//    sql.select {
 //      val p = from(input)
 //      val a = join(Table<Address>()) { a -> a.ownerId == p.id }
 //      selector(p) to a
 //    }
-//  val myQuery = capture {
+//  val myQuery = sql {
 //    val martians =
 //      myFunction(Table<Martian>().filter { it.title == "Maartok" }) { m -> m.title }
 //    val people =

--- a/testing/src/jvmMain/kotlin/io/exoquery/ActionStuff.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/ActionStuff.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 fun main() {
   data class Name(val first: String, val last: String)
@@ -11,7 +11,7 @@ fun main() {
   data class PersonSimple3(val age: Int)
 
 //  val output = printSourceBefore {
-//    capture {
+//    sql {
 //      insert<Person> { set(name to "Joe", age to 123) }
 //    }
 //  }
@@ -27,7 +27,7 @@ fun main() {
   val ps3 = PersonSimple3(123)
 
   val s =
-    capture {
+    sql {
       //insert<Person> { set(name.first to param(n.first), age to 123) }.returning { p -> Name(p.name.first + "-stuff", p.name.last + "-otherStuff") }
       // TODO Odd error need to figure out: Exception in thread "main" java.lang.NoClassDefFoundError: I
       //insert<Person> { setParams(p) }.returning { p -> Name(p.name.first + "-stuff", p.name.last + "-otherStuff") }

--- a/testing/src/jvmMain/kotlin/io/exoquery/BatchActionStuff.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/BatchActionStuff.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 fun main() {
   data class Name(val first: String, val last: String)
@@ -11,7 +11,7 @@ fun main() {
   data class PersonSimple3(val age: Int)
 
 //  val output = printSourceBefore {
-//    capture {
+//    sql {
 //      insert<Person> { set(name to "Joe", age to 123) }
 //    }
 //  }
@@ -39,7 +39,7 @@ fun main() {
 
   // TODO when using setParams why the heck does it use a contextual serializer for the String??? Need to test for that case (even the regular actions should test for that case!)
   val s =
-    capture.batch(peopleSeq) { p ->
+    sql.batch(peopleSeq) { p ->
       //insert<Person> { set(name.first to param(n.first), age to 123) }.returning { p -> Name(p.name.first + "-stuff", p.name.last + "-otherStuff") }
       // TODO Odd error need to figure out: Exception in thread "main" java.lang.NoClassDefFoundError: I
       insert<PersonSimple> { setParams(p) } //.returning { p -> Name(p.name.first + "-stuff", p.name.last + "-otherStuff") }

--- a/testing/src/jvmMain/kotlin/io/exoquery/CapFun.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/CapFun.kt
@@ -2,11 +2,11 @@ package io.exoqueryCapturedFunctionParamKinds
 
 import io.exoquery.*
 import io.exoquery.annotation.CapturedFunction
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.PostgresDialect
 
 data class MyPerson(val id: Long, val name: String)
 
-val q = capture.select {
+val q = sql.select {
   val p = from(MyCaptureAheadObject.people("Jack"))
   p
 }
@@ -14,10 +14,10 @@ val q = capture.select {
 
 object MyCaptureAheadObject {
   @CapturedFunction
-  fun peopleNested(filter: String) = capture { Table<MyPerson>().filter { p -> p.name == filter } }
+  fun peopleNested(filter: String) = sql { Table<MyPerson>().filter { p -> p.name == filter } }
 
   @CapturedFunction
-  fun people(filter: String) = capture { peopleNested(filter) }
+  fun people(filter: String) = sql { peopleNested(filter) }
 }
 
 fun main() {

--- a/testing/src/jvmMain/kotlin/io/exoquery/CodeGenExample.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/CodeGenExample.kt
@@ -7,7 +7,7 @@ import io.exoquery.generation.DatabaseDriver
 
 
 fun main() {
-  //val cc = capture.generateAndReturn(
+  //val cc = sql.generateAndReturn(
   //  Code.Entities(
   //    CodeVersion.Fixed("1.2"),
   //    DatabaseDriver.Postgres("jdbc:postgresql://localhost:5432/postgres"),

--- a/testing/src/jvmMain/kotlin/io/exoquery/CodeGenExampleOpenAPI.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/CodeGenExampleOpenAPI.kt
@@ -15,7 +15,7 @@ package io.exoquery
  * ```
  */
 fun main() {
-  //val cc = capture.generateAndReturn(
+  //val cc = sql.generateAndReturn(
   //  Code.Entities(
   //    CodeVersion.Fixed("1.5"),
   //    DatabaseDriver.Postgres("jdbc:postgresql://localhost:5432/postgres"),

--- a/testing/src/jvmMain/kotlin/io/exoquery/FlatTest.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/FlatTest.kt
@@ -1,6 +1,6 @@
 package io.exoquery
 
-import io.exoquery.sql.PostgresDialect //hello
+import io.exoquery.PostgresDialect //hello
 
 fun main() {
   data class Person(val id: Int, val name: String, val age: Int)
@@ -8,7 +8,7 @@ fun main() {
   data class Robot(val ownerId: Int, val name: String, val model: String)
 
   val cap =
-    capture {
+    sql {
       Table<Person>().flatMap { p ->
         internal.flatJoin(Table<Address>()) { a -> p.id == a.ownerId }.map { a -> p to a }
           .flatMap { pa ->

--- a/testing/src/jvmMain/kotlin/io/exoquery/FromFlat.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/FromFlat.kt
@@ -8,16 +8,16 @@ package io.exoquery
 //
 //
 //  @CapturedFunction
-//  fun Person.joinAddress() = capture {
+//  fun Person.joinAddress() = sql {
 //    flatJoin(Table<Address>()) { a -> this@Person.id == a.ownerId }
 //  }
 //
 //  @CapturedFunction
-//  fun Person.joinRobot() = capture {
+//  fun Person.joinRobot() = sql {
 //    flatJoin(Table<Robot>()) { r -> this@Person.id == r.ownerId }
 //  }
 //
-//  val cap = capture.select {
+//  val cap = sql.select {
 //    val p = from(Table<Person>())
 //    val a = from(p.joinAddress())
 //    val r = from(p.joinRobot())
@@ -36,16 +36,16 @@ package io.exoquery
 //
 //
 //  @CapturedFunction
-//  fun Person.joinAddress() = capture {
+//  fun Person.joinAddress() = sql {
 //    flatJoin(Table<Address>()) { a -> this@Person.id == a.ownerId }
 //  }
 //
 //  @CapturedFunction
-//  fun Person.joinRobot() = capture {
+//  fun Person.joinRobot() = sql {
 //    flatJoin(Table<Robot>()) { r -> this@Person.id == r.ownerId }
 //  }
 //
-//  val cap = capture.select {
+//  val cap = sql.select {
 //    val p = from(Table<Person>())
 //    val a = from(p.joinAddress())
 //    val r = from(p.joinRobot())

--- a/testing/src/jvmMain/kotlin/io/exoquery/MoreStuff.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/MoreStuff.kt
@@ -18,13 +18,13 @@ package io.exoquery
 //    fun <T> insert(insertBlock: (T).() -> Values): T
 //  }
 //
-//  fun capture(block: CaptureBlock.() -> Unit): Unit = TODO()
+//  fun sql(block: CaptureBlock.() -> Unit): Unit = TODO()
 //
 //
 //  fun use() {
 //    data class Person(val id: Int, val name: String, val age: Int)
 //
-//    capture {
+//    sql {
 //      // can't do it like this
 //      insert<Person> { values(set[name] = "Joe") }
 //    }
@@ -47,7 +47,7 @@ object Variant2 {
     fun <T> insert(insertBlock: (T).() -> Values): T
   }
 
-  fun capture(block: CaptureBlock.() -> Unit): Unit = TODO()
+  fun sql(block: CaptureBlock.() -> Unit): Unit = TODO()
 
 
   fun use() {
@@ -56,7 +56,7 @@ object Variant2 {
     // TODO write returningColumns after values function
 
 
-    capture {
+    sql {
       insert<Person> { set(name to "Leah", age to 9) }
     }
 
@@ -70,7 +70,7 @@ object Variant3 {
   fun use() {
     data class Person(val id: Int, val name: String, val age: Int)
 
-    capture {
+    sql {
       insert<Person> {
         it[name] = "Leah"
         it[age] = 9
@@ -93,7 +93,7 @@ object Variant3 {
     fun <T> insert(insertBlock: (T).(Setter) -> Unit): T
   }
 
-  fun capture(block: CaptureBlock.() -> Unit): Unit = TODO()
+  fun sql(block: CaptureBlock.() -> Unit): Unit = TODO()
 
 
 }

--- a/testing/src/jvmMain/kotlin/io/exoquery/QueryExample.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/QueryExample.kt
@@ -5,7 +5,7 @@ fun main() {
   data class Person(val id: Int, val name: String, val age: Int)
 
   val cap =
-    capture {
+    sql {
       Table<Person>().filter { p -> p.name == "Joe" }
     }
 

--- a/testing/src/jvmMain/kotlin/io/exoquery/RenamingExample.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/RenamingExample.kt
@@ -6,7 +6,7 @@ fun main() {
   data class Emb(@ExoField("A") val a: Int, @ExoField("B") val b: Int)
   data class Parent(val id: Int, val emb1: Emb)
 
-  val q = capture {
+  val q = sql {
     Table<Emb>().map { e -> Parent(1, e) }.distinct()
   }.dyanmic()
   println(q.buildPrettyFor.Postgres().value)

--- a/testing/src/jvmMain/kotlin/io/exoquery/Stuff.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/Stuff.kt
@@ -1,5 +1,5 @@
-import io.exoquery.capture
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.sql
+import io.exoquery.PostgresDialect
 
 ////@file:TracesEnabled(TraceType.SqlNormalizations::class, TraceType.Normalizations::class)
 //
@@ -21,29 +21,29 @@ import io.exoquery.sql.PostgresDialect
 //  data class Person(val id: Int, val name: String, val age: Int)
 //  data class Address(val ownerId: Int, val street: String, val zip: Int)
 //
-//  val joes = capture { Table<Person>().filter { p -> p.name == param("joe") } }
+//  val joes = sql { Table<Person>().filter { p -> p.name == param("joe") } }
 //
 //  // TODO introduce a spec for these
 //
 //  @CapturedFunction
 //  fun isJoe(name: String) =
-//    capture.expression { name == "joe" }
+//    sql.expression { name == "joe" }
 //
-//  val result = capture {
+//  val result = sql {
 //    joes.filter { isJoe(it.name).use }.map { it.name }
 //  }
 //
 //
 ////  @CapturedFunction
 ////  fun <T> joinPeopleToAddress(people: SqlQuery<T>, otherValue: String, f: (T) -> Int) =
-////    capture.select {
+////    sql.select {
 ////      val p = from(people)
 ////      val a = join(Table<Address>()) { a -> a.ownerId == f(p) && a.street == otherValue } // should have a verification that param(otherValue) fails
 ////      p to a
 ////    }
 ////
 ////  val r = "foobar"
-////  val result = capture {
+////  val result = sql {
 ////    joinPeopleToAddress(joes, param(r)) { it.id }.map { kv -> kv.first.name to kv.second.street }
 ////  }
 //
@@ -52,18 +52,18 @@ import io.exoquery.sql.PostgresDialect
 //
 ////  @CapturedFunction
 ////  fun <T> joinPeopleToAddress(people: SqlQuery<T>, f: (T, Address) -> Boolean) =
-////    capture.select {
+////    sql.select {
 ////      val p = from(people)
 ////      val a = join(Table<Address>()) { a -> f(p, a) }
 ////      p to a
 ////    }
 ////
-////  val joinFunction = capture.expression {
+////  val joinFunction = sql.expression {
 ////    { p: Person, a: Address -> p.id == a.ownerId }
 ////  }
 ////  // TODO captured-function for SqlExpression
 ////
-////  val result = capture {
+////  val result = sql {
 ////    joinPeopleToAddress(joes) { p, a -> joinFunction.use(p, a) /*p.id == a.ownerId*/ }.map { kv -> kv.first.name + " lives at " + kv.second.street }
 ////  }
 //
@@ -86,7 +86,7 @@ import io.exoquery.sql.PostgresDialect
 ////   }
 ////  println("hello")
 ////
-////  val x = capture {
+////  val x = sql {
 ////    joinPeopleToAddress2.use.invoke(joes)
 ////  }
 ////  println(x.buildPretty(PostgresDialect()).value) // helloo
@@ -143,7 +143,7 @@ fun main() {
 //  }
 //  println(s)
 
-  val q = capture {
+  val q = sql {
     Table<Person>().map { p -> p.name?.first ?: "John" }
   }
   println(q.build<PostgresDialect>())

--- a/testing/src/jvmMain/kotlin/io/exoquery/comapre/ParamStuff.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/comapre/ParamStuff.kt
@@ -1,12 +1,12 @@
 //package io.exoquery.comapre
 //
 //import io.exoquery.testdata.Person
-//import io.exoquery.capture
+//import io.exoquery.sql
 //
 //fun main() {
 //  val n = "Joe"
 //  fun stuff() = "joe"
-//  val q = capture {
+//  val q = sql {
 //    Table<Person>().filter { p -> p.name == param(stuff()) }
 //  }
 //}

--- a/testing/src/jvmMain/kotlin/io/exoquery/debug/Debug.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/debug/Debug.kt
@@ -1,33 +1,13 @@
 package io.exoquery.debug
 
-import io.exoquery.SqlQuery
 import io.exoquery.capture
-import io.exoquery.printSource
-import io.exoquery.printSourceBefore
 
 data class MyPerson(val name: String)
 
-object BackObject {
+fun main() {
   val people = capture.select {
     val p = from(Table<MyPerson>())
     p
   }
-}
-
-
-
-fun main() {
-  //val src = printSourceBefore {
-  //  capture.select {
-  //    val x = from(BackObject.people)
-  //    x
-  //  }
-  //}
-  //println(src)
-
-  //val cap = capture.select {
-  //  val x = from(BackObject.people)
-  //  x
-  //}
-  //println(cap.buildFor.Postgres())
+  println(people.buildFor.Postgres().value)
 }

--- a/testing/src/jvmMain/kotlin/io/exoquery/sample/CapturedDynamic.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/sample/CapturedDynamic.kt
@@ -2,7 +2,7 @@ package io.exoquery.sample
 
 import io.exoquery.SqlQuery
 import io.exoquery.annotation.CapturedFunction
-import io.exoquery.capture
+import io.exoquery.sql
 
 fun main() {
   data class Person(val id: Int, val name: String, val age: Int)
@@ -11,11 +11,11 @@ fun main() {
 
 
   @CapturedFunction
-  fun <T: Person> forUpdate(v: SqlQuery<T>) = capture {
+  fun <T: Person> forUpdate(v: SqlQuery<T>) = sql {
     free("${v} FOR UPDATE").asPure<SqlQuery<T>>()
   }
 
-  val q = capture {
+  val q = sql {
     forUpdate(Table<Person>().filter { p -> p.age > 21 })
   }.dyanmic()
 
@@ -23,7 +23,7 @@ fun main() {
   println(q.buildFor.Postgres().value)
 
   // TODO put this into a unit test
-  //val q = capture.select {
+  //val q = sql.select {
   //  val p = from(Table<Person>())
   //  val a = join(Table<Address>()) { a -> p.id == a.ownerId }
   //  val r = join(Table<Robot>()) { r -> p.id == r.ownerId }
@@ -40,7 +40,7 @@ fun main() {
   //  //> }
   //
   //
-  //val q2 = capture {
+  //val q2 = sql {
   //  Table<Person>().flatMap { p ->
   //    internal.flatJoin(Table<Address>()) { a -> p.id == a.ownerId }.flatMap { a ->
   //      internal.flatJoin(Table<Robot>()) { r -> p.id == r.ownerId }.map { r ->

--- a/testing/src/jvmMain/kotlin/io/exoquery/sample/CapturedFunctionExample.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/sample/CapturedFunctionExample.kt
@@ -1,23 +1,23 @@
 package io.exoquery.sample
 
 import io.exoquery.annotation.CapturedFunction
-import io.exoquery.capture
+import io.exoquery.sql
 
 fun main() {
   data class Stock(val weight: Double, val sharesOutstanding: Int, val price: Double, val earnings: Double)
 
   @CapturedFunction
-  fun peRatioWeighted(stock: Stock, weight: Double) = capture.expression {
+  fun peRatioWeighted(stock: Stock, weight: Double) = sql.expression {
     (stock.price / stock.earnings) * weight
   }
 
   // A extension function used in the query!
   @CapturedFunction
-  fun Stock.marketCap() = capture.expression {
+  fun Stock.marketCap() = sql.expression {
     price * sharesOutstanding
   }
 
-  val q = capture {
+  val q = sql {
     val totalWeight = Table<Stock>().map { it.marketCap().use }.sum() // A local variable used in the query!
     Table<Stock>().map { stock -> peRatioWeighted(stock, stock.marketCap().use / totalWeight) }
   }

--- a/testing/src/jvmMain/kotlin/io/exoquery/sample/HavingTest.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/sample/HavingTest.kt
@@ -1,12 +1,12 @@
 package io.exoquery.sample
 
-import io.exoquery.capture
+import io.exoquery.sql
 
 fun main() {
   data class Person(val id: Int, val name: String, val age: Int)
   data class Address(val ownerId: Int, val street: String)
 
-  val q = capture.select {
+  val q = sql.select {
     val p = from(Table<Person>())
     val a = join(Table<Address>()) { a -> a.ownerId == p.id }
     groupBy(p.name) // comment this out and error should result

--- a/testing/src/jvmMain/kotlin/io/exoquery/sample/QueryForwardValue.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/sample/QueryForwardValue.kt
@@ -1,9 +1,7 @@
 package io.exoquery.sample
 
-import io.exoquery.SqlQuery
-import io.exoquery.annotation.CapturedFunction
-import io.exoquery.capture
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.sql
+import io.exoquery.PostgresDialect
 
 data class Someone(val name: String)
 
@@ -13,7 +11,7 @@ fun main() {
 }
 
 fun runBefore() {
-  val q = capture {
+  val q = sql {
     MyExampleAhead.people().filter { p -> p.name == "Jack" }
   }
   val result = q.buildPretty<PostgresDialect>()
@@ -22,18 +20,18 @@ fun runBefore() {
 
 object MyExampleAhead {
   // Need to see what happens with this after the previous and reversed
-  fun people2() = capture {
+  fun people2() = sql {
     Table<Someone>().filter { it.name == "Jack" }
   }
 
-  fun people() = capture {
+  fun people() = sql {
     people2().filter { it.name == "Joe" }
   }
 }
 
 fun runAfter() {
   // This is just to show that the can run
-  val q = capture {
+  val q = sql {
     MyExampleAhead.people().filter { p -> p.name == "Jack" }
   }
   val result = q.buildPretty<PostgresDialect>()

--- a/testing/src/jvmMain/kotlin/io/exoquery/sample/QueryWithReturning.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/sample/QueryWithReturning.kt
@@ -2,8 +2,8 @@ package io.exoquery.sample
 
 import io.exoquery.SqlQuery
 import io.exoquery.annotation.CapturedFunction
-import io.exoquery.capture
-import io.exoquery.sql.PostgresDialect
+import io.exoquery.sql
+import io.exoquery.PostgresDialect
 
 interface Nameable {
   val name: String
@@ -17,12 +17,12 @@ fun main() {
 
   @CapturedFunction
   fun <N: Nameable> nameIsJoe(input: SqlQuery<N>) =
-    capture {
+    sql {
       input.filter { p -> p.name == "Joe" }.map { p -> p.name }
     }
 
   // TODO add this case to the unit tests
-//  val q = capture {
+//  val q = sql {
 //    nameIsJoe(
 //      Table<Robot>().filter { r ->
 //        Table<Factory>().filter { f -> f.id == r.factoryId }.filter { f -> f.name == "aaa" }.isNotEmpty()
@@ -36,13 +36,13 @@ fun main() {
 
   @CapturedFunction
   fun robotsWithFactoryName(factoryName: String) =
-    capture {
+    sql {
       Table<Robot>().filter { r ->
         Table<Factory>().filter { f -> f.id == r.factoryId }.filter { f -> f.name == factoryName }.isNotEmpty()
       }
     }
 
-  val q = capture {
+  val q = sql {
     nameIsJoe(
       robotsWithFactoryName("aaa") unionAll robotsWithFactoryName("bbb")
     )

--- a/testing/src/jvmTest/kotlin/io/exoquery/MultiFieldReq.kt
+++ b/testing/src/jvmTest/kotlin/io/exoquery/MultiFieldReq.kt
@@ -6,7 +6,7 @@ class MultiFieldReq: GoldenSpecDynamic(MultiFieldReqGoldenDynamic, Mode.ExoGolde
     data class Address(val ownerId: Int, val street: String, val city: String)
 
     "by whole record" {
-      val people = capture.select {
+      val people = sql.select {
         val p = from(Table<Person>())
         val a = join(Table<Address>()) { a -> a.ownerId == p.id }
         groupBy(p)
@@ -17,12 +17,12 @@ class MultiFieldReq: GoldenSpecDynamic(MultiFieldReqGoldenDynamic, Mode.ExoGolde
     }
 
     "multiple-nested" {
-      val a = capture.select {
+      val a = sql.select {
         val p = from(Table<Person>())
         val a = join(Table<Address>()) { a -> a.ownerId == p.id }
         Pair(Pair(p, a.street), a)
       }
-      val b = capture.select {
+      val b = sql.select {
         val av = from(a)
         groupBy(av.first)
         av.first to count(av.second.street)
@@ -37,12 +37,12 @@ class MultiFieldReq: GoldenSpecDynamic(MultiFieldReqGoldenDynamic, Mode.ExoGolde
       data class OuterProduct(val pws: PersonWithStreet, val address: Address)
       data class GroupedProduct(val pws: PersonWithStreet, val streetCount: Int)
 
-      val a = capture.select {
+      val a = sql.select {
         val p = from(Table<Person>())
         val a = join(Table<Address>()) { a -> a.ownerId == p.id }
         OuterProduct(PersonWithStreet(p, a.street), a)
       }
-      val b = capture.select {
+      val b = sql.select {
         val av = from(a)
         groupBy(av.pws)
         GroupedProduct(av.pws, count(av.address.street))

--- a/testing/src/jvmTest/kotlin/io/exoquery/codegen/GenerationSpec.kt
+++ b/testing/src/jvmTest/kotlin/io/exoquery/codegen/GenerationSpec.kt
@@ -1,7 +1,7 @@
 package io.exoquery.codegen
 
 import io.exoquery.PostgresTestDB
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.codegen.model.JdbcGenerator
 import io.exoquery.codegen.model.NameParser
 import io.exoquery.codegen.util.JdbcSchemaReader
@@ -128,7 +128,7 @@ class GenerationSpec: FreeSpec({
   // }
   // We need to account for this structure by skipping the variables in the block and then looking them up later
   "should lookup vars when out of order" {
-    capture.generateJustReturn(
+    sql.generateJustReturn(
       Code.Entities(
         CodeVersion.Fixed("1.0.0"),
         DatabaseDriver.Postgres("jdbc:postgresql://localhost:5432/postgres?search_path=public,purposely_inconsistent"),

--- a/testing/src/jvmTest/kotlin/io/exoquery/codegen/UnliftingSpec.kt
+++ b/testing/src/jvmTest/kotlin/io/exoquery/codegen/UnliftingSpec.kt
@@ -1,6 +1,6 @@
 package io.exoquery.codegen
 
-import io.exoquery.capture
+import io.exoquery.sql
 import io.exoquery.codegen.model.LLM
 import io.exoquery.codegen.model.NameParser
 import io.exoquery.codegen.model.UnrecognizedTypeStrategy
@@ -17,7 +17,7 @@ import io.kotest.matchers.shouldBe
 class UnliftingSpec: FreeSpec({
   "unlift version" - {
     "fixed" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B")
@@ -28,7 +28,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "floating" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Floating,
           DatabaseDriver.Custom("A", "B")
@@ -41,7 +41,7 @@ class UnliftingSpec: FreeSpec({
   }
   "unlift driver" - {
     "postgres" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Postgres("A")
@@ -52,7 +52,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "mysql" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.MySQL("A")
@@ -63,7 +63,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "sqlite" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.SQLite("A")
@@ -74,7 +74,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "h2" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.H2("A")
@@ -85,7 +85,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "oracle" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Oracle("A")
@@ -96,7 +96,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "sqlserver" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.SqlServer("A")
@@ -107,7 +107,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "custom" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B")
@@ -120,7 +120,7 @@ class UnliftingSpec: FreeSpec({
   }
   "unlift NameParser" - {
     "literal" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B"),
@@ -133,7 +133,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "snake case" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B"),
@@ -147,7 +147,7 @@ class UnliftingSpec: FreeSpec({
     }
     "using llm" -  {
       "ollama" {
-        capture.generateJustReturn(
+        sql.generateJustReturn(
           Code.Entities(
             CodeVersion.Fixed("0"),
             DatabaseDriver.Custom("A", "B"),
@@ -160,7 +160,7 @@ class UnliftingSpec: FreeSpec({
         )
       }
       "openai" {
-        capture.generateJustReturn(
+        sql.generateJustReturn(
           Code.Entities(
             CodeVersion.Fixed("0"),
             DatabaseDriver.Custom("A", "B"),
@@ -177,7 +177,7 @@ class UnliftingSpec: FreeSpec({
 
   "unlift TableGrouping" - {
     "schema per package" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B"),
@@ -190,7 +190,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "single package" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B"),
@@ -206,7 +206,7 @@ class UnliftingSpec: FreeSpec({
 
   "unlift UnrecognizedTypeStrategy" - {
     "throw" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B"),
@@ -219,7 +219,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "skip column" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B"),
@@ -232,7 +232,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "use string" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B"),
@@ -248,7 +248,7 @@ class UnliftingSpec: FreeSpec({
 
   "unlift TypeMap" - {
     "using just column" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B"),
@@ -265,7 +265,7 @@ class UnliftingSpec: FreeSpec({
       )
     }
     "using all fields" {
-      capture.generateJustReturn(
+      sql.generateJustReturn(
         Code.Entities(
           CodeVersion.Fixed("0"),
           DatabaseDriver.Custom("A", "B"),
@@ -285,7 +285,7 @@ class UnliftingSpec: FreeSpec({
 
   // test out plugging in values into all of the nullable/defaultable arguments oc Code.Entities
   "top level Code.Entities constants" {
-    capture.generateJustReturn(
+    sql.generateJustReturn(
       Code.Entities(
         CodeVersion.Fixed("0"),
         DatabaseDriver.Custom("A", "B"),


### PR DESCRIPTION
**Migration to the new DSL construct:**

* Replaced all usages of the `capture` function and `capture.select`/`capture.expression` blocks with `sql`, `sql.select`, and `sql.expression` throughout the documentation, including code examples and explanations.

**Documentation improvements:**

* Updated all descriptive text to refer to `sql` instead of `capture`, including section headings, feature explanations, and usage notes.

**Feature clarification in README.md**

* Updated the documentation in `README.md` to consistently use the new `sql` construct instead of the deprecated `capture` function for building SQL queries with ExoQuery. The changes clarify how to use the DSL and compiler plugin, update all code examples, and improve explanations for key features.
* Clarified the role of the `sql` construct as both a builder DSL and a compile-time capture mechanism, and described how the compiler plugin reifies queries.
