### PR TITLE
Adding some common SQL functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,6 +931,51 @@ be used arbitrarily. They can only contain a single `capture`, `capture.select`,
 They cannot have any other kind of control logic (e.g. `if`, `when`, `for`, etc.) inside of them. If you want
 a more flexible mechanism for writing queries see the [dynamic queries](#dynamic-queries) section below.
 
+### Common SQL Functions
+
+This section summarizes the most common string functions you can use directly inside captured SQL blocks. There are two sources of functions:
+
+- Kotlin String methods that are whitelisted by the compiler plugin (via MethodWhiteList) and translated by SqlIdiom
+- Additional helper methods available via the StringSqlDsl
+
+Supported Kotlin String methods (via MethodWhiteList):
+- substring(start, end) → SUBSTRING(column, start, end)
+- uppercase() → UPPER(column)
+- lowercase() → LOWER(column)
+- length → LENGTH/CHAR_LENGTH (dialect-dependent; may be rendered as LEN in some dialects)
+- trim() → TRIM(column)
+  - Note: Only the zero-argument variation is supported. If you need to trim specific characters or trim only one side, use the StringSqlDsl helpers below.
+
+StringSqlDsl helpers you can call on string expressions inside a captured block:
+- left(n: Int) → LEFT(column, n)
+- right(n: Int) → RIGHT(column, n)
+- replace(old: String, new: String) → REPLACE(column, old, new)
+- substring(start: Int, end: Int) → SUBSTRING(column, start, end)
+- uppercase() → UPPER(column)
+- lowercase() → LOWER(column)
+- trimBoth(charsToTrim: String) → TRIM(BOTH charsToTrim FROM column)
+- trimRight(charsToTrim: String) → TRIM(TRAILING charsToTrim FROM column)
+- trimLeft(charsToTrim: String) → TRIM(LEADING charsToTrim FROM column)
+
+Examples:
+```kotlin
+sql.select {
+  val p = from(Table<Person>())
+  // Kotlin String methods (whitelisted)
+  val a = p.name.substring(1, 3)      // SUBSTRING(p.name, 1, 3)
+  val b = p.name.uppercase()           // UPPER(p.name)
+  val c = p.name.lowercase()           // LOWER(p.name)
+  val d = p.name.trim()                // TRIM(p.name) – only zero-arg is supported
+  val e = p.name.length                // LENGTH(p.name) or LEN(p.name) depending on dialect
+
+  // StringSqlDsl helpers
+  val f = p.name.left(5)               // LEFT(p.name, 5)
+  val g = p.name.right(2)              // RIGHT(p.name, 2)
+  val h = p.name.replace(" ", "_")   // REPLACE(p.name, ' ', '_')
+  val i = p.name.trimBoth("_")        // TRIM(BOTH '_' FROM p.name)
+}
+```
+
 ### Polymorphic Query Abstraction
 
 Continuing from the section on [captured-functions](#captured-functions) above, captured functions can use generics and

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/Dsl.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/Dsl.kt
@@ -163,6 +163,15 @@ interface StringSqlDsl {
 
   @DslFunctionCall(DslFunctionCallType.PureFunction::class)
   fun lowercase(): String = errorCap("The `upperCase` expression of the Query was not inlined")
+
+  @DslFunctionCall(DslFunctionCallType.PureFunction::class)
+  fun trimBoth(charsToTrim: String): String = errorCap("The `trimBoth` expression of the Query was not inlined")
+
+  @DslFunctionCall(DslFunctionCallType.PureFunction::class)
+  fun trimRight(charsToTrim: String): String = errorCap("The `trimRight` expression of the Query was not inlined")
+
+  @DslFunctionCall(DslFunctionCallType.PureFunction::class)
+  fun trimLeft(charsToTrim: String): String = errorCap("The `trimLeft` expression of the Query was not inlined")
 }
 
 
@@ -332,6 +341,12 @@ interface CapturedBlock {
    */
   @DslNestingIgnore
   val String.sql @DslNestingIgnore get(): StringSqlDsl = errorCap("The `sql-dsl` expression of the Query was not inlined")
+
+  @DslFunctionCall(DslFunctionCallType.PureFunction::class)
+  fun String.like(pattern: String): Boolean = errorCap("The `like` expression of the Query was not inlined")
+
+  @DslFunctionCall(DslFunctionCallType.PureFunction::class)
+  fun String.ilike(pattern: String): Boolean = errorCap("The `like` expression of the Query was not inlined")
 
   @Dsl
   fun <T> SqlQuery<T>.nested(): SqlQuery<T> = errorCap("The `nested` expression of the Query was not inlined")

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlIdiom.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlIdiom.kt
@@ -284,10 +284,16 @@ interface SqlIdiom : HasPhasePrinting {
             name == "startsWith" -> stringStartsWith(head, args.first())
             name == "uppercase" -> +"UPPER(${head.token})"
             name == "lowercase" -> +"LOWER(${head.token})"
+            name == "like" -> +"${head.token} LIKE ${args.first().token}"
+            name == "ilike" -> +"${head.token} ILIKE ${args.first().token}"
+            name == "trim" -> +"TRIM(${head.token})"
+            name == "trimBoth" -> +"TRIM(BOTH ${args.first().token} FROM ${head.token})"
+            name == "trimRight" -> +"TRIM(TRAILING ${args.first().token} FROM ${head.token})"
+            name == "trimLeft" -> +"TRIM(LEADING ${args.first().token} FROM ${head.token})"
             name == "left" -> +"LEFT(${head.token}, ${args.first().token})"
             name == "right" -> +"RIGHT(${head.token}, ${args.first().token})"
             name == "replace" -> +"REPLACE(${head.token}, ${args.first().token}, ${args.last().token})"
-            else -> xrError("Unknown or invalid XR.MethodCall method: ${name} in the expression:\n${this.showRaw()}")
+            else -> xrError("Unknown or invalid XR.MethodCall String method: `${name}` in the expression:\n${this.showRaw()}")
           }
         }
         head is XR.Query && name == "isNotEmpty" -> +"EXISTS (${head.token})"
@@ -304,7 +310,7 @@ interface SqlIdiom : HasPhasePrinting {
         // Need to think about situations where it is a CallType.PureFunction/ImpureFunction and see how it needs to be expanded. Something with sub-expansion
         // might be necessary e.g. sub-expading the XR.Query with SqlQuery if needed
 
-        else -> xrError("Unknown or invalid XR.MethodCall method: ${name} in the expression:\n${this.showRaw()}")
+        else -> xrError("Unknown or invalid XR.MethodCall method (from ${originalHostType.toString()}): `${name}` in the expression:\n${this.showRaw()}")
       }
     }
 

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/XR.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/XR.kt
@@ -282,6 +282,23 @@ sealed interface XR {
 
       val Empty = ClassId(FqName.Empty, FqName.Empty, emptyList(), false)
     }
+
+    override fun toString(): String =
+      buildString {
+        append(packageFqName.toString())
+        if (packageFqName.path.isNotEmpty()) {
+          append(".")
+        }
+        append(relativeClassName.toString())
+        if (typeArgs.isNotEmpty()) {
+          append("<")
+          append(typeArgs.joinToString(", ") { it.toString() })
+          append(">")
+        }
+        if (nullable) {
+          append("?")
+        }
+      }
   }
 
   /**

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/CompileExtensions.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/CompileExtensions.kt
@@ -117,6 +117,11 @@ val IrCall.regularArgs get() = run {
   val args = this.arguments
   params.filter { param -> param.kind == IrParameterKind.Regular }.map { args[it] }
 }
+
+val IrCall.allArgsCount get() = run {
+  this.symbol.owner.parameters.size
+}
+
 val IrCall.regularArgsCount get() = run {
   val params = this.symbol.owner.parameters
   params.count { param -> param.kind == IrParameterKind.Regular }

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/MethodWhitelist.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/MethodWhitelist.kt
@@ -2,17 +2,25 @@ package io.exoquery.plugin.trees
 
 import io.exoquery.plugin.classIdOf
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
 
 // TODO need to introduce CallType to know what is pure and what is not. Also need to ahve equivalent data-structure for global calls
 object MethodWhitelist {
-  data class HostMethods(val host: ClassId, val allowedMethods: List<String>)
+  data class HostMethods(val host: ClassId, val allowedMethods: List<AllowedMethod>)
+  data class AllowedMethod(val name: String, val expectedNumArgs: Int? = null)
 
   private inline fun <reified T> classIdOrFail(label: String) = classIdOf<T>() ?: throw IllegalArgumentException("Cannot create MethodWhitelist. Cannot get classId of: ${label}")
 
   private val data: List<HostMethods> =
     listOf(
-      HostMethods(classIdOrFail<String>("String"), listOf("substring", "uppercase", "lowercase", "length"))
+      HostMethods(classIdOrFail<String>("String"),
+        listOf(
+          AllowedMethod("substring"),
+          AllowedMethod("uppercase"),
+          AllowedMethod("lowercase"),
+          AllowedMethod("length"),
+          AllowedMethod("trim", 1),
+        )
+      )
     )
 
   private val dataMap = data.map { it.host to it.allowedMethods }.toMap()
@@ -20,9 +28,14 @@ object MethodWhitelist {
   private val allHosts = data.map { it.host }
 
   fun allowedHost(host: ClassId) = data.find { it.host == host } != null
-  fun allowedMethodForHost(host: ClassId?, method: String?): Boolean =
+  fun allowedMethodForHost(host: ClassId?, method: String?, numArgs: Int): Boolean =
     if (host == null || method == null)
       false
     else
-      dataMap[host]?.let { it.contains(method) } ?: false
+      dataMap[host]?.let {
+        // We have an entry for the particular host-type and the expected number of args matches the actual args of the call
+        it.any {
+          it.name == method && (it.expectedNumArgs == null || it.expectedNumArgs == numArgs)
+        }
+      } ?: false
 }

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParseExpression.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParseExpression.kt
@@ -143,9 +143,9 @@ object ParseExpression {
 
       // TODO cannot assume all whitelisted methods are pure functions. Need to introduce purity/impurity to the whitelist
       case(Ir.Call.FunctionMemN[Is { it.type.classId()?.let { MethodWhitelist.allowedHost(it) } ?: false }, Is(), Is()])
-        .thenIfThis { _, _ -> MethodWhitelist.allowedMethodForHost(this.type.classId(), funName) }
+        .thenIfThis { _, _ -> MethodWhitelist.allowedMethodForHost(this.type.classId(), funName, this.allArgsCount) }
         .thenThis { head, args ->
-          val classId = this.type.classId() ?: parseError("Cannot determine the classId of the type ${this.type.dumpKotlinLike()} of this expression.", this)
+          val classId = head.type.classId() ?: parseError("Cannot determine the classId of the type ${this.type.dumpKotlinLike()} of this expression.", this)
           val argsXR = args.map { parse(it) }
           val isKotlinSynthetic = this.hasSameOffsetsAs(head)
           XR.MethodCall(parse(head), funName, argsXR, XR.CallType.PureFunction, classId.toXR(), isKotlinSynthetic, XRType.Value, expr.loc)

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/Parser.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/Parser.kt
@@ -140,7 +140,7 @@ object CallParser {
           head = Parser.parseArg(reciever),
           name = nameOverride ?: expr.symbol.safeName,
           args = extractArgs(expr.regularArgs),
-          originalHostType = expr.type.classId()?.toXR() ?: XR.ClassId.Empty,
+          originalHostType = reciever.type.classId()?.toXR() ?: XR.ClassId.Empty,
           type = tpe,
           loc = expr.loc,
           isKotlinSynthetic = reciever.hasSameOffsetsAs(expr),

--- a/testing/src/commonTest/kotlin/io/exoquery/ExpressionFunctionReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ExpressionFunctionReq.kt
@@ -63,6 +63,30 @@ class ExpressionFunctionReq : GoldenSpecDynamic(ExpressionFunctionReqGoldenDynam
       val q = sql { Table<Person>().map { p -> p.name.sql.lowercase() } }
       shouldBeGolden(q.build<PostgresDialect>())
     }
+    "trim" {
+      val q = sql { Table<Person>().map { p -> p.name.trim() } }
+      shouldBeGolden(q.build<PostgresDialect>())
+    }
+    "trimBoth" {
+      val q = sql { Table<Person>().map { p -> p.name.sql.trimBoth("x") } }
+      shouldBeGolden(q.build<PostgresDialect>())
+    }
+    "trimRight" {
+      val q = sql { Table<Person>().map { p -> p.name.sql.trimRight("x") } }
+      shouldBeGolden(q.build<PostgresDialect>())
+    }
+    "trimLeft" {
+      val q = sql { Table<Person>().map { p -> p.name.sql.trimLeft("x") } }
+      shouldBeGolden(q.build<PostgresDialect>())
+    }
+    "like" {
+      val q = sql { Table<Person>().map { p -> p.name.like("J%") } }
+      shouldBeGolden(q.build<PostgresDialect>())
+    }
+    "ilike" {
+      val q = sql { Table<Person>().map { p -> p.name.ilike("j%") } }
+      shouldBeGolden(q.build<PostgresDialect>())
+    }
   }
   "StringInterpolation" - {
     "multiple elements" {

--- a/testing/src/commonTest/kotlin/io/exoquery/ExpressionFunctionReqGoldenDynamic.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/ExpressionFunctionReqGoldenDynamic.kt
@@ -42,80 +42,23 @@ object ExpressionFunctionReqGoldenDynamic: GoldenQueryFile {
     "String/lower - sql" to cr(
       "SELECT LOWER(p.name) AS value FROM Person p"
     ),
-    "StringInterpolation/multiple elements" to cr(
-      "SELECT p.name || '-' || p.age AS value FROM Person p"
+    "String/trim" to cr(
+      "SELECT TRIM(p.name) AS value FROM Person p"
     ),
-    "StringInterpolation/single element" to cr(
-      "SELECT p.name AS value FROM Person p"
+    "String/trimBoth" to cr(
+      "SELECT TRIM(BOTH 'x' FROM p.name) AS value FROM Person p"
     ),
-    "StringInterpolation/single constant" to cr(
-      "SELECT 'constant' AS value FROM Person p"
+    "String/trimRight" to cr(
+      "SELECT TRIM(TRAILING 'x' FROM p.name) AS value FROM Person p"
     ),
-    "StringInterpolation/many elements" to cr(
-      "SELECT l.name || '-foo-' || l.age || '-bar-' || l.address || '-baz-' || l.phone || '-blin' AS value FROM LotsOfFields l"
+    "String/trimLeft" to cr(
+      "SELECT TRIM(LEADING 'x' FROM p.name) AS value FROM Person p"
     ),
-    "Int/toLong" to cr(
-      "SELECT p.age AS value FROM Person p"
+    "String/like" to cr(
+      "SELECT p.name LIKE 'J%' AS value FROM Person p"
     ),
-    "Int/toDouble" to cr(
-      "SELECT CAST(p.age AS DOUBLE PRECISION) AS value FROM Person p"
-    ),
-    "Int/toFloat" to cr(
-      "SELECT CAST(p.age AS REAL) AS value FROM Person p"
-    ),
-    "Long/toInt" to cr(
-      "SELECT p.age AS value FROM Person p"
-    ),
-    "Long/toDouble" to cr(
-      "SELECT CAST(p.age AS DOUBLE PRECISION) AS value FROM Person p"
-    ),
-    "Long/toFloat" to cr(
-      "SELECT CAST(p.age AS REAL) AS value FROM Person p"
-    ),
-    "Float/toInt" to cr(
-      "SELECT p.age AS value FROM Person p"
-    ),
-    "Float/toLong" to cr(
-      "SELECT p.age AS value FROM Person p"
-    ),
-    "Float/toDouble" to cr(
-      "SELECT CAST(p.age AS DOUBLE PRECISION) AS value FROM Person p"
-    ),
-    "String/toInt" to cr(
-      "SELECT CAST(p.name AS INTEGER) AS value FROM Person p"
-    ),
-    "String/toLong" to cr(
-      "SELECT CAST(p.name AS BIGINT) AS value FROM Person p"
-    ),
-    "String/toBoolean" to cr(
-      "SELECT CAST(p.name AS BOOLEAN) AS value FROM Person p"
-    ),
-    "String/casting" to cr(
-      "SELECT p.name || p.age AS value FROM Person p"
-    ),
-    "String/string concat" to cr(
-      "SELECT p.name || ' ' || p.name AS value FROM Person p"
-    ),
-    "String/substr - regular" to cr(
-      "SELECT SUBSTRING(p.name, 1, 2) AS value FROM Person p"
-    ),
-    "String/substr" to cr(
-      "SELECT SUBSTRING(p.name, 1, 2) AS value FROM Person p"
-    ),
-    "String/left" to cr(
-      "SELECT LEFT(p.name, 2) AS value FROM Person p"
-    ),
-    "String/right" to cr(
-      "SELECT RIGHT(p.name, 2) AS value FROM Person p"
-    ),
-    "String/replace" to cr(
-      "SELECT REPLACE(p.name, 'a', 'b') AS value FROM Person p"
-    ),
-    "String/upper - sql" to cr(
-      "SELECT UPPER(p.name) AS value FROM Person p"
-    ),
-    "String/lower - sql" to cr(
-      "SELECT LOWER(p.name) AS value FROM Person p"
+    "String/ilike" to cr(
+      "SELECT p.name ILIKE 'j%' AS value FROM Person p"
     ),
     "StringInterpolation/multiple elements" to cr(
       "SELECT p.name || '-' || p.age AS value FROM Person p"


### PR DESCRIPTION
This pull request adds support for additional SQL string functions and improves the handling of method whitelisting and translation in the query engine. The changes include new string manipulation functions, expanded method whitelisting logic, updates to SQL rendering, and enhancements to testing and documentation.

### SQL String Function Support

* Added new string manipulation functions to `StringSqlDsl`: `trimBoth`, `trimRight`, and `trimLeft`, allowing more granular trimming of characters from string columns in SQL queries.
* Introduced `like` and `ilike` functions to `CapturedBlock`, enabling SQL LIKE and ILIKE pattern matching directly in query expressions.
* Updated `SqlIdiom` to translate new string functions (`trim`, `trimBoth`, `trimRight`, `trimLeft`, `like`, `ilike`) into their corresponding SQL syntax.

### Method Whitelisting Improvements

* Refactored `MethodWhitelist` to support argument count validation for whitelisted methods, ensuring only allowed methods with the correct number of arguments are used in captured blocks.
* Updated expression parsing logic to use the new whitelisting mechanism, passing argument counts to improve method validation.

### Testing and Documentation

* Added new golden tests for the introduced string functions, verifying correct SQL generation for `trim`, `trimBoth`, `trimRight`, `trimLeft`, `like`, and `ilike`.
