### PR TITLE
Improve flatJoin API

### DIFF
--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/Dsl.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/Dsl.kt
@@ -179,15 +179,15 @@ interface StringSqlDsl {
 // no values of this should ever be created (that is called a "phantom type" in various circles)
 
 
-sealed interface CapturedBlockInternal {
+sealed interface CapturedBlockCompose {
   @Dsl
   @FlatJoin
-  fun <T> flatJoin(query: SqlQuery<T>, cond: (T) -> Boolean): SqlQuery<T> =
+  fun <T> join(query: SqlQuery<T>, cond: (T) -> Boolean): SqlQuery<T> =
     errorCap("The `flatJoin` expression of the Query was not inlined")
 
   @Dsl
   @FlatJoinLeft
-  fun <T> flatJoinLeft(query: SqlQuery<T>, cond: (T) -> Boolean): SqlQuery<T?> =
+  fun <T> joinLeft(query: SqlQuery<T>, cond: (T) -> Boolean): SqlQuery<T?> =
     errorCap("The `flatJoinLeft` expression of the Query was not inlined")
 }
 
@@ -489,7 +489,7 @@ interface CapturedBlock {
   fun FreeBlock.asConditon(): Boolean = errorCap("The `invoke` expression of the Query was not inlined")
   fun FreeBlock.asPureConditon(): Boolean = errorCap("The `invoke` expression of the Query was not inlined")
 
-  val internal: CapturedBlockInternal
+  val composeFrom: CapturedBlockCompose
 
   @Dsl
   @ParamStatic(ParamSerializer.String::class)

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParseQuery.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParseQuery.kt
@@ -205,15 +205,15 @@ object ParseQuery {
       case(ExtractorsDomain.Call.UseExpression.Receiver[Is()]).thenThis { head ->
         ParseExpression.parse(head).asQuery()
       },
-      case(Ir.Call.FunctionMemN[Is(), Is.of("flatJoin", "flatJoinLeft"), Is()]).thenIfThis { _, _ -> ownerHasAnnotation<FlatJoin>() || ownerHasAnnotation<FlatJoinLeft>() }.thenThis { _, args ->
+      case(Ir.Call.FunctionMemN[Ir.Expr.ClassOf<CapturedBlockCompose>(), Is.of("join", "joinLeft"), Is()]).thenIfThis { _, _ -> ownerHasAnnotation<FlatJoin>() || ownerHasAnnotation<FlatJoinLeft>() }.thenThis { _, args ->
         on(args[1]).match(
           case(Ir.FunctionExpression.withBlock[Is(), Is()]).thenThis { params, block ->
             val cond = ParseExpression.parseFunctionBlockBody(block)
             val id = params.first().makeIdent()
             when (symName) {
-              "flatJoin" -> XR.FlatJoin(XR.JoinType.Inner, ParseQuery.parse(args[0]), id, cond, expr.loc)
-              "flatJoinLeft" -> XR.FlatJoin(XR.JoinType.Left, ParseQuery.parse(args[0]), id, cond, expr.loc)
-              else -> parseError("Invalid flatJoin method: ${symName}", expr)
+              "join" -> XR.FlatJoin(XR.JoinType.Inner, ParseQuery.parse(args[0]), id, cond, expr.loc)
+              "joinLeft" -> XR.FlatJoin(XR.JoinType.Left, ParseQuery.parse(args[0]), id, cond, expr.loc)
+              else -> parseError("Invalid composeFrom.join method: ${symName}", expr)
             }
           }
         ) ?: parseError("Could not parse flatJoin", expr)

--- a/testing/src/commonTest/kotlin/io/exoquery/MonadicMachineryReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/MonadicMachineryReq.kt
@@ -8,11 +8,11 @@ import io.exoquery.testdata.Robot
 class MonadicMachineryReq: GoldenSpecDynamic(MonadicMachineryReqGoldenDynamic, Mode.ExoGoldenTest(), {
   "sql.expression.(Row)->Table" {
     val joinAddress = sql.expression {
-      { p: Person -> internal.flatJoin(Table<Address>()) { a -> p.id == a.ownerId } }
+      { p: Person -> composeFrom.join(Table<Address>()) { a -> p.id == a.ownerId } }
     }
 
     val joinRobot = sql.expression {
-      { p: Person -> internal.flatJoin(Table<Robot>()) { r -> p.id == r.ownerId } }
+      { p: Person -> composeFrom.join(Table<Robot>()) { r -> p.id == r.ownerId } }
     }
 
     val cap = sql.select {
@@ -28,12 +28,12 @@ class MonadicMachineryReq: GoldenSpecDynamic(MonadicMachineryReqGoldenDynamic, M
   "sql.expression.(@Cap (Row)->Table).use" {
     @SqlFragment
     fun joinAddress(p: Person) = sql.expression {
-      internal.flatJoin(Table<Address>()) { a -> p.id == a.ownerId }
+      composeFrom.join(Table<Address>()) { a -> p.id == a.ownerId }
     }
 
     @SqlFragment
     fun joinRobot(p: Person) = sql.expression {
-      internal.flatJoin(Table<Robot>()) { r -> p.id == r.ownerId }
+      composeFrom.join(Table<Robot>()) { r -> p.id == r.ownerId }
     }
 
     val cap = sql.select {
@@ -46,15 +46,36 @@ class MonadicMachineryReq: GoldenSpecDynamic(MonadicMachineryReqGoldenDynamic, M
     shouldBeGolden(cap.xr, "XR")
     shouldBeGolden(cap.build<PostgresDialect>(), "SQL")
   }
+  "sql.(@Cap (Row)->Table).use" {
+    @SqlFragment
+    fun joinAddress(p: Person) = sql {
+      composeFrom.join(Table<Address>()) { a -> p.id == a.ownerId }
+    }
+
+    @SqlFragment
+    fun joinRobot(p: Person) = sql {
+      composeFrom.join(Table<Robot>()) { r -> p.id == r.ownerId }
+    }
+
+    val cap = sql.select {
+      val p = from(Table<Person>())
+      val a = from(joinAddress(p))
+      val r = from(joinRobot(p))
+      Triple(p, a, r)
+    }
+
+    shouldBeGolden(cap.xr, "XR")
+    shouldBeGolden(cap.build<PostgresDialect>(), "SQL")
+  }
   "sql.expression.use.(@Cap (Row)()->Table)" {
     @SqlFragment
     fun Person.joinAddress() = sql.expression {
-      internal.flatJoin(Table<Address>()) { a -> this@joinAddress.id == a.ownerId }
+      composeFrom.join(Table<Address>()) { a -> this@joinAddress.id == a.ownerId }
     }
 
     @SqlFragment
     fun Person.joinRobot() = sql.expression {
-      internal.flatJoin(Table<Robot>()) { r -> this@joinRobot.id == r.ownerId }
+      composeFrom.join(Table<Robot>()) { r -> this@joinRobot.id == r.ownerId }
     }
 
     val cap = sql.select {
@@ -71,12 +92,12 @@ class MonadicMachineryReq: GoldenSpecDynamic(MonadicMachineryReqGoldenDynamic, M
   "sql.(@Cap (Row)()->Table)" {
     @SqlFragment
     fun Person.joinAddress() = sql {
-      internal.flatJoin(Table<Address>()) { a -> this@joinAddress.id == a.ownerId }
+      composeFrom.join(Table<Address>()) { a -> this@joinAddress.id == a.ownerId }
     }
 
     @SqlFragment
     fun Person.joinRobot() = sql {
-      internal.flatJoin(Table<Robot>()) { r -> this@joinRobot.id == r.ownerId }
+      composeFrom.join(Table<Robot>()) { r -> this@joinRobot.id == r.ownerId }
     }
 
     val cap = sql.select {

--- a/testing/src/commonTest/kotlin/io/exoquery/MonadicMachineryReqGoldenDynamic.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/MonadicMachineryReqGoldenDynamic.kt
@@ -18,6 +18,12 @@ object MonadicMachineryReqGoldenDynamic: GoldenQueryFile {
     "sql expression (@Cap (Row)->Table) use/SQL" to cr(
       "SELECT p.id, p.name, p.age, a.ownerId, a.street, a.city, r.ownerId, r.name, r.model FROM Person p INNER JOIN Address a ON p.id = a.ownerId INNER JOIN Robot r ON p.id = r.ownerId"
     ),
+    "sql (@Cap (Row)->Table) use/XR" to kt(
+      "select { val p = from(Table(Person)); val a = from({ p -> Table(Address).join { a -> p.id == a.ownerId } }.toQuery.apply(p)); val r = from({ p -> Table(Robot).join { r -> p.id == r.ownerId } }.toQuery.apply(p)); Triple(first = p, second = a, third = r) }"
+    ),
+    "sql (@Cap (Row)->Table) use/SQL" to cr(
+      "SELECT p.id, p.name, p.age, a.ownerId, a.street, a.city, r.ownerId, r.name, r.model FROM Person p INNER JOIN Address a ON p.id = a.ownerId INNER JOIN Robot r ON p.id = r.ownerId"
+    ),
     "sql expression use (@Cap (Row)()->Table)/XR" to kt(
       "select { val p = from(Table(Person)); val a = from({ this -> Table(Address).join { a -> this.id == a.ownerId }.toExpr }.apply(p).toQuery); val r = from({ this -> Table(Robot).join { r -> this.id == r.ownerId }.toExpr }.apply(p).toQuery); Triple(first = p, second = a, third = r) }"
     ),

--- a/testing/src/jvmMain/kotlin/io/exoquery/FlatTest.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/FlatTest.kt
@@ -1,7 +1,5 @@
 package io.exoquery
 
-import io.exoquery.PostgresDialect //hello
-
 fun main() {
   data class Person(val id: Int, val name: String, val age: Int)
   data class Address(val ownerId: Int, val street: String, val city: String)
@@ -10,9 +8,9 @@ fun main() {
   val cap =
     sql {
       Table<Person>().flatMap { p ->
-        internal.flatJoin(Table<Address>()) { a -> p.id == a.ownerId }.map { a -> p to a }
+        composeFrom.join(Table<Address>()) { a -> p.id == a.ownerId }.map { a -> p to a }
           .flatMap { pa ->
-            internal.flatJoin(Table<Robot>()) { r -> pa.first.id == r.ownerId }
+            composeFrom.join(Table<Robot>()) { r -> pa.first.id == r.ownerId }
               .map { r -> Triple(pa.first, pa.second, r) }
           }
       }


### PR DESCRIPTION
This pull request refactors the SQL join DSL in the ExoQuery codebase, replacing the old `flatJoin` and `flatJoinLeft` methods with new `composeFrom.join` and `composeFrom.joinLeft` methods. It introduces a new interface, `CapturedBlockCompose`, to encapsulate these join operations, and updates all references and tests to use the new naming and interface. The changes improve clarity and consistency in the DSL, making flatJoin operations more intuitive for users.

**DSL Refactor and API Renaming:**

* Replaced the `CapturedBlockInternal` interface with `CapturedBlockCompose`, and renamed the methods `flatJoin`/`flatJoinLeft` to `join`/`joinLeft` for more natural SQL-like semantics in `exoquery-engine/src/commonMain/kotlin/io/exoquery/Dsl.kt`. All references to the old interface and methods were updated accordingly. [[1]](diffhunk://#diff-e77dd59005f101964669b13c5139eece7d26f6756f8ebf5fad4f08898cbdfb8aL182-R190) [[2]](diffhunk://#diff-e77dd59005f101964669b13c5139eece7d26f6756f8ebf5fad4f08898cbdfb8aL492-R492)
* Updated the query parser in `exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParseQuery.kt` to recognize and process the new `join`/`joinLeft` methods from `CapturedBlockCompose`, ensuring correct translation to internal representations.
