### PR TITLE
Fix error duplication by actually providing accurate position data

### DIFF
--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/CodegenFileBuilder.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/CodegenFileBuilder.kt
@@ -6,6 +6,7 @@ import io.exoquery.config.ExoCompileOptions
 import io.exoquery.generation.Code
 import io.exoquery.generation.toGenerator
 import io.exoquery.parseError
+import io.exoquery.parseErrorAtCurrent
 import io.exoquery.plugin.logging.Messages.AttemptingToUseLLMWhenDisabled
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.name
@@ -19,7 +20,7 @@ class CodegenFileBuilder(val options: ExoCompileOptions) {
       // TODO double check this works as intended
       when (val aiConfig = dc.nameParser.findFirstConfigWithAI()) {
         is NameParser.UsingLLM if (!options.enableCodegenAI) -> {
-          parseError(AttemptingToUseLLMWhenDisabled(dc.driver.jdbcUrl, aiConfig))
+          parseErrorAtCurrent(AttemptingToUseLLMWhenDisabled(dc.driver.jdbcUrl, aiConfig))
         }
       }
 

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/ComputeEngineTracing.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/ComputeEngineTracing.kt
@@ -2,6 +2,7 @@ package io.exoquery.plugin.transform
 
 import io.exoquery.annotation.TracesEnabled
 import io.exoquery.parseError
+import io.exoquery.parseErrorAtCurrent
 import io.exoquery.plugin.getAnnotation
 import io.exoquery.plugin.isClass
 import io.exoquery.plugin.logging.CompileLogger
@@ -35,7 +36,7 @@ object ComputeEngineTracing {
     val traceTypesClsRef = getFileTraceAnnotations() + dialectType.getTraceAnnotationArgs()
     val traceTypesNames =
       traceTypesClsRef
-        .map { ref -> (ref as? IrClassReference) ?: parseError("Invalid Trace Type: ${ref.source() ?: ref.dumpKotlinLike()} was not a class-reference:\n${ref.dumpSimple()}") }
+        .map { ref -> (ref as? IrClassReference) ?: parseErrorAtCurrent("Invalid Trace Type: ${ref.source() ?: ref.dumpKotlinLike()} was not a class-reference:\n${ref.dumpSimple()}") }
         .mapNotNull { ref ->
           // it's TracesEnabled(KClass<TraceType.Normalizations>, etc...) so we need to take 1st argument from the type
           val shortName = ref.type.simpleTypeArgs.first().classFqName?.shortName()?.asString()

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCaptureCodegenRead.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCaptureCodegenRead.kt
@@ -28,7 +28,7 @@ class TransformCaptureCodegenRead(val codegenAccum: FileCodegenAccum) : Transfor
       on(expression).match(
         case(ExtractorsDomain.Call.CaptureGenerate[Is(), Is()]).then { codeDataClassConstructor, callType ->
           val arg = codeDataClassConstructor.regularArgs[0]
-          Unlifter.unliftCodeEntities(arg ?: parseError("case class codegen argument was null")) to callType
+          Unlifter.unliftCodeEntities(arg ?: parseError("case class codegen argument was null", expression)) to callType
         }
       ) ?: parseError(
         Messages.UnexpectedCodegenCall,

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCapturedExpression.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCapturedExpression.kt
@@ -58,7 +58,7 @@ class TransformCapturedExpression(val superTransformer: VisitTransformExpression
       val body = superTransformer.visitBlockBody(bodyRaw) as IrBlockBody
       val (xr, dynamics) = Parser.scoped { Parser.parseFunctionBlockBody(body) }
 
-      val xrExpr = xr as? XR.Expression ?: parseError("Could not parse to expression:\n${xr}")
+      val xrExpr = xr as? XR.Expression ?: parseError("Could not parse to expression", expression)
       xrExpr to dynamics
     }
   }

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCompileQuery.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCompileQuery.kt
@@ -266,7 +266,7 @@ class TransformCompileQuery(val superTransformer: VisitTransformExpressions) : T
           type.isClass<SqlQuery<*>>() -> Query
           type.isClass<SqlAction<*, *>>() -> Action
           type.isClass<SqlBatchAction<*, *, *>>() -> BatchAction
-          else -> parseError("The type ${type.dumpKotlinLike()} must be a SqlQuery or SqlAction but it was not")
+          else -> parseErrorAtCurrent("The type ${type.dumpKotlinLike()} must be a SqlQuery or SqlAction but it was not")
         }
     }
   }
@@ -297,10 +297,10 @@ object ConstructCompiletimeDialect {
     when {
       "io.exoquery.PostgresDialect" in fullPath -> PostgresDialect(traceConfig)
       else ->
-        (Class.forName(fullPath) ?: parseError("Could not find the dialect class: ${fullPath}"))
+        (Class.forName(fullPath) ?: parseErrorAtCurrent("Could not find the dialect class: ${fullPath}"))
           .constructors.find {
             it.parameters.size == 1 && it.parameters.first().type.kotlin.isSuperclassOf(TraceConfig::class)
           }?.let { it.newInstance(traceConfig) } as SqlIdiom
-          ?: parseError("The dialect class ${fullPath} must have a 1-arg constructor that takes a trace-config but it did not")
+          ?: parseErrorAtCurrent("The dialect class ${fullPath} must have a 1-arg constructor that takes a trace-config but it did not")
     }
 }

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformPrintSource.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformPrintSource.kt
@@ -112,7 +112,7 @@ class TransformPrintSource(val superTransformer: VisitTransformExpressions) : Tr
         )
       }
     }
-      ?: parseError("Parsing Failed\n================== The expresson was not a Global Function (with one argument-block): ==================\n" + expression.dumpKotlinLike() + "\n--------------------------\n" + expression.dumpSimple())
+      ?: parseError("The expression was not a Global Function (with one argument-block)", expression)
 
   context(CX.Scope, CX.Builder)
   fun transformPrintSource(argsRaw: MatchedType, applySuperTransform: Boolean = true) = run {

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformSelectClause.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformSelectClause.kt
@@ -52,7 +52,7 @@ class TransformSelectClause(val superTransformer: VisitTransformExpressions) : T
           }
           // TODO use Messages.kt, use better example
         )
-          ?: parseError("Parsing Failed\n================== The clause was not a property select-expression (was the owner annotated correctly?): ==================\n" + selectExpressionRaw.dumpKotlinLike() + "\n--------------------------\n" + selectExpressionRaw.dumpSimple())
+          ?: parseError("The clause was not a property select-expression (was the owner annotated correctly?)", selectExpressionRaw)
 
       val (selectClause, dynamics) = Parser.scoped { Parser.parseSelectClauseLambda(selectLambda) }
       // Store the selectClause inside a XR.CustomQueryRef instance so that we can invoke the XR serialization and "plant" it into the IR

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/VisitTransformExpressions.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/VisitTransformExpressions.kt
@@ -177,9 +177,7 @@ class VisitTransformExpressions(
           runBlock()
         } catch (e: ParseError) {
           // builderContext.logger.error(e.msg, e.location ?: expression.location(currentFile.fileEntry))
-          scopeContext.logger.error(
-            e.fullMessageWithStackTrace(),
-          )
+          scopeContext.logger.error(e.fullMessageWithStackTrace(), e.location ?: expression.location(scopeContext.currentFile.fileEntry))
           expression
         } catch (e: TransformXrError) {
           val location = expression.location(scopeContext.currentFile.fileEntry)
@@ -252,7 +250,7 @@ class VisitTransformExpressions(
     val transformScaffoldAnnotatedFunctionCall = TransformScaffoldAnnotatedFunctionCall(this, "[ExoQuery: VisitTransformExpressions-VisitCall]")
     val transformReadCodegen = TransformCaptureCodegenRead(data.codegenAccum)
 
-    val runner = ScopedRunner(scopeCtx, builderContext, data, false)
+    val runner = ScopedRunner(scopeCtx, builderContext, data, true)
     return runner.run(expression) {
       when {
         transformScaffoldAnnotatedFunctionCall.matches(expression) -> transformScaffoldAnnotatedFunctionCall.transform(expression)

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ExtractorsDomain.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ExtractorsDomain.kt
@@ -163,12 +163,12 @@ object ExtractorsDomain {
           call.symbol.safeName == "<init>" -> {
             val className: String = call.type.classFqName?.sanitizedClassName() ?: call.type.dumpKotlinLike()
             if (!call.symbol.owner.isPrimary)
-              parseError("Detected construction of the class ${className} using a non-primary constructor. This is not allowed.")
+              parseError("Detected construction of the class ${className} using a non-primary constructor. This is not allowed.", call)
 
             val params = call.symbol.owner.regularParams.map { it.name.asString() }.toList()
             val args = call.regularArgs.toList()
             if (params.size != args.size)
-              parseError("Cannot parse constructor of ${className} its params ${params} do not have the same cardinality as its arguments ${args.map { it?.dumpKotlinLike() }}")
+              parseError("Cannot parse constructor of ${className} its params ${params} do not have the same cardinality as its arguments ${args.map { it?.dumpKotlinLike() }}", call)
             val fields = (params zip args).map { (name, value) -> Field(name, value) }
             Components1(Data(className, fields))
           }
@@ -184,12 +184,12 @@ object ExtractorsDomain {
           call.symbol.safeName == "<init>" && call.symbol.owner.regularParams.size == 1 -> {
             val className: String = call.type.classFqName?.asString() ?: call.type.dumpKotlinLike()
             if (!call.symbol.owner.isPrimary)
-              parseError("Detected construction of the class ${className} using a non-primary constructor. This is not allowed.")
+              parseError("Detected construction of the class ${className} using a non-primary constructor. This is not allowed.", call)
 
             val params = call.symbol.owner.regularParams.map { it.name.asString() }.toList()
             val args = call.regularArgs.toList()
             if (params.size != args.size)
-              parseError("Cannot parse constructor of ${className} its params ${params} do not have the same cardinality as its arguments ${args.map { it?.dumpKotlinLike() }}")
+              parseError("Cannot parse constructor of ${className} its params ${params} do not have the same cardinality as its arguments ${args.map { it?.dumpKotlinLike() }}", call)
             Components2(className, args.first())
           }
           else -> null
@@ -206,12 +206,12 @@ object ExtractorsDomain {
           call.symbol.safeName == "<init>" && call.symbol.owner.regularParams.size >= 1 -> {
             val className: String = call.type.classFqName?.asString() ?: call.type.dumpKotlinLike()
             if (!call.symbol.owner.isPrimary)
-              parseError("Detected construction of the class ${className} using a non-primary constructor. This is not allowed.")
+              parseErrorAtCurrent("Detected construction of the class ${className} using a non-primary constructor. This is not allowed.")
 
             val params = call.symbol.owner.regularParams.map { it.name.asString() }.toList()
             val args = call.regularArgs.toList()
             if (params.size != args.size)
-              parseError("Cannot parse constructor of ${className} its params ${params} do not have the same cardinality as its arguments ${args.map { it?.dumpKotlinLike() }}")
+              parseErrorAtCurrent("Cannot parse constructor of ${className} its params ${params} do not have the same cardinality as its arguments ${args.map { it?.dumpKotlinLike() }}")
             Components2(className, args.first())
           }
           else -> null

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/MakeExpr.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/MakeExpr.kt
@@ -2,6 +2,7 @@ package io.exoquery.plugin.trees
 
 import io.exoquery.liftingError
 import io.exoquery.parseError
+import io.exoquery.parseErrorAtCurrent
 import io.exoquery.plugin.classId
 import io.exoquery.plugin.transform.CX
 import org.jetbrains.kotlin.ir.builders.irCall
@@ -24,8 +25,8 @@ import kotlin.reflect.typeOf
 context(CX.Scope)
 fun KType.fullPathOfBasic(): ClassId =
   when (val cls = this.classifier) {
-    is KClass<*> -> cls.classId() ?: parseError("Could not find the class id for the class: $cls")
-    else -> parseError("Invalid list class: $cls")
+    is KClass<*> -> cls.classId() ?: parseErrorAtCurrent("Could not find the class id for the class: $cls")
+    else -> parseErrorAtCurrent("Invalid list class: $cls")
   }
 
 // TODO this can probably make both objects and types if we check the attributes of the reified type T
@@ -52,10 +53,10 @@ context(CX.Scope, CX.Builder) fun makeClassFromString(fullPath: String, args: Li
 // Blows up here with a strange error if you put 'run' for the body of the function without specifying a return type
 // Caused by: java.lang.IllegalStateException: Arguments and parameters size mismatch: arguments.size = 1, parameters.size = 2
 context(CX.Scope, CX.Builder) fun makeClassFromId(fullPath: ClassId, args: List<IrExpression>, types: List<IrType> = listOf(), overrideType: IrType? = null): IrConstructorCall {
-  val cls = pluginCtx.referenceClass(fullPath) ?: parseError("Could not find the reference for a class in the context: $fullPath")
+  val cls = pluginCtx.referenceClass(fullPath) ?: parseErrorAtCurrent("Could not find the reference for a class in the context: $fullPath")
 
   if (!cls.owner.isClass && !cls.owner.isAnnotationClass)
-    parseError("Attempting to create an instance of $fullPath which is not a class")
+    parseErrorAtCurrent("Attempting to create an instance of $fullPath which is not a class")
 
   return (cls.constructors.firstOrNull() ?: liftingError("Could not find a constructor for a class in the context: $fullPath"))
     .let { ctor ->
@@ -73,10 +74,10 @@ context(CX.Scope, CX.Builder) fun makeClassFromId(fullPath: ClassId, args: List<
 }
 
 context(CX.Scope, CX.Builder) fun makeObjectFromId(id: ClassId): IrGetObjectValue {
-  val clsSym = pluginCtx.referenceClass(id) ?: parseError("Could not find the reference for a class in the context: $id")
+  val clsSym = pluginCtx.referenceClass(id) ?: parseErrorAtCurrent("Could not find the reference for a class in the context: $id")
 
   if (!clsSym.owner.isObject)
-    parseError("Attempting to create an object-instance of $id which is not an object")
+    parseErrorAtCurrent("Attempting to create an object-instance of $id which is not an object")
 
   val tpe = clsSym.owner.defaultType
   return builder.irGetObjectValue(tpe, clsSym)

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParseQuery.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/ParseQuery.kt
@@ -92,7 +92,6 @@ object ParseQuery {
                       """|${e.message}
                          |----------------- This Occurred in a Problematic Scaffold Expansion -----------------
                          |${this.prepareForPrinting().dumpKotlinLike()}
-                         |-------------------------------------------------------------------------------------
                       """.trimMargin(), it)
                   }
                 }
@@ -264,7 +263,7 @@ object ParseQuery {
         }
       },
       case(Ir.Call.FunctionMem0[Ir.Expr.ClassOf<CapturedBlock>(), Is("Table")]).thenThis { _, _ ->
-        entityFromType(this.typeArguments[0] ?: parseError("Type arguemnt of Table() call was not found>"), this)
+        entityFromType(this.typeArguments[0] ?: parseError("Type arguemnt of Table() call was not found>", expr), this)
       },
       // This is the select defined in the sql-block (that returns SqlQuery<T> as opposed to the top-level one which returns @Captured SqlQuery<T>.
       case(Ir.Call.FunctionMem1[Ir.Expr.ClassOf<CapturedBlock>(), Is("select"), Ir.FunctionExpression[Is()]]).thenThis { _, (selectLambda) ->

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/Types.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/Types.kt
@@ -2,6 +2,7 @@ package io.exoquery.plugin.trees
 
 import io.exoquery.SqliteDialect
 import io.exoquery.parseError
+import io.exoquery.parseErrorAtCurrent
 import io.exoquery.plugin.transform.CX
 import io.exoquery.plugin.typeOfClass
 import org.jetbrains.kotlin.ir.types.IrType
@@ -12,7 +13,7 @@ object Types {
   context(CX.Scope)
   fun sqliteDialect(): IrType =
     sqlDialectValue ?: run {
-      val tpe = typeOfClass<SqliteDialect>() ?: parseError("No type for SQLiteDialect found, this is a bug in the plugin")
+      val tpe = typeOfClass<SqliteDialect>() ?: parseErrorAtCurrent("No type for SQLiteDialect found, this is a bug in the plugin")
       sqlDialectValue = tpe
       sqlDialectValue!!
     }

--- a/testing-compile/src/test/kotlin/io/exoquery/InvalidCapturedFunctionReq.kt
+++ b/testing-compile/src/test/kotlin/io/exoquery/InvalidCapturedFunctionReq.kt
@@ -1,0 +1,85 @@
+package io.exoquery
+
+class InvalidCapturedFunctionReq : MessageSpecDynamic(InvalidCapturedFunctionReqGoldenDynamic, Mode.ExoGoldenTest(), {
+  "error if captured function is not a SqlQuery<T> or SqlExpression<T>" {
+    shouldBeGoldenError(
+      """
+      import io.exoquery.*
+      import io.exoquery.annotation.SqlFragment
+      data class MyPerson(val name: String, val age: Int)
+      @SqlFragment
+      fun externalFunction(name: String) = name + "_suffix"
+      fun run() {
+        val q = sql { Table<MyPerson>().filter { p -> externalFunction(p.name) == "Joe" } }
+        println(q.buildFor.Postgres().value)
+      }
+      """.trimIndent()
+    )
+  }
+
+  /**
+   * A Captured Function is traversed at least twice, once during the VisitTransformExpressions phase and potentially once again
+   * during the bubble-up traversal of the TransformAnnotatedFunction phase. Both of these call-chains eventually end up detecting
+   * that the Captured Function has an invalid return type and report errors, however if there is no stack-trace reported in the error
+   * the Kotlin compiler will de-duplicate the error messages (since they have the same text and location) and only show one of them.
+   * This is the correct and desired behavior.
+   *
+   * In situations where we want to see the full stack trace however, the two errors will no longer be identical. In that situation
+   * will will have two different stack trace appear for example:
+   * ```
+   * // This:
+   * [ExoQuery] Could not understand an expression or query due to an error: The SqlFragment had the wrong kind of return type
+   * ...
+   * ----------------- Stack Trace: -----------------
+   * at io.exoquery.ParseErrorCompanion.withFullMsg(ParseError.kt:84)
+   * at io.exoquery.ParseErrorKt.parseError(ParseError.kt:129)
+   * at io.exoquery.ParseErrorKt.parseErrordefault(ParseError.kt:128)
+   * at io.exoquery.plugin.transform.TransformAnnotatedFunction.transform(TransformAnnotatedFunction.kt:125)
+   * at io.exoquery.plugin.transform.TransformScaffoldAnnotatedFunctionCall.transform(TransformScaffoldAnnotatedFunctionCall.kt:75)
+   * at io.exoquery.plugin.transform.VisitTransformExpressions.visitCalllambda1(VisitTransformExpressions.kt:256)
+   * at io.exoquery.plugin.transform.VisitTransformExpressionsScopedRunner.runlambda0runBlock(VisitTransformExpressions.kt:174)
+   * at io.exoquery.plugin.transform.VisitTransformExpressionsScopedRunner.run(VisitTransformExpressions.kt:177)
+   * at io.exoquery.plugin.transform.VisitTransformExpressions.visitCall(VisitTransformExpressions.kt:254)
+   * at io.exoquery.plugin.transform.VisitTransformExpressions.visitCall(VisitTransformExpressions.kt:38)
+   * ... (truncated)
+   * // ...and this:
+   * [ExoQuery] Could not understand an expression or query due to an error: The SqlFragment had the wrong kind of return type
+   * ...
+   * ----------------- Stack Trace: -----------------
+   * at io.exoquery.ParseErrorCompanion.withFullMsg(ParseError.kt:84)
+   * at io.exoquery.ParseErrorKt.parseError(ParseError.kt:129)
+   * at io.exoquery.ParseErrorKt.parseErrordefault(ParseError.kt:128)
+   * at io.exoquery.plugin.trees.ParseExpression.parse(ParseExpression.kt:567)
+   * at io.exoquery.plugin.trees.ParseExpressionparseinlinedthenThis19.invoke(ThenPattern1.kt:148)
+   * at io.decomat.StageCase.eval(Matching.kt:68)
+   * at io.decomat.DoMatch.match(Matching.kt:29)
+   * at io.exoquery.plugin.trees.ParseExpression.parse(ParseExpression.kt:115)
+   * at io.exoquery.plugin.trees.ParseExpressionparseFunctionBlockBodyinlinedthen1.invoke(ThenPattern1.kt:147)
+   * at io.decomat.StageCase.eval(Matching.kt:68)
+   * ... (truncated)
+   * ```
+   * However, since stack traces change so often (i.e. whenever a source file is modified even in the slightest way) it is
+   * identical anymore therefore it is not practical to include them in golden tests so there is a mechanism in MessageFileKotlinMaker
+   * that reduces an error stack to a single message [Excluding X lines] where X is the number of lines in the original stack trace.
+   * This allows us to still verify that stack traces are being generated while not caring about their exact content.
+   *
+   * Since there are two different stack traces in this test case but MessageFileKotlinMaker reduces both of them to the same
+   * [Excluding X lines] message the final output of both errors will look the same but it represents two different error stacks.
+   */
+  "error if captured function is not a SqlQuery<T> or SqlExpression<T> - with details" {
+    shouldBeGoldenError(
+      """
+      @file:io.exoquery.annotation.ErrorDetailsEnabled(false)
+      import io.exoquery.*
+      import io.exoquery.annotation.SqlFragment
+      data class MyPerson(val name: String, val age: Int)
+      @SqlFragment
+      fun externalFunction(name: String) = name + "_suffix"
+      fun run() {
+        val q = sql { Table<MyPerson>().filter { p -> externalFunction(p.name) == "Joe" } }
+        println(q.buildFor.Postgres().value)
+      }
+      """.trimIndent()
+    )
+  }
+})

--- a/testing-compile/src/test/kotlin/io/exoquery/InvalidCapturedFunctionReqGoldenDynamic.kt
+++ b/testing-compile/src/test/kotlin/io/exoquery/InvalidCapturedFunctionReqGoldenDynamic.kt
@@ -1,0 +1,91 @@
+package io.exoquery
+
+import io.exoquery.printing.GoldenResult
+import io.exoquery.printing.cr
+import io.exoquery.printing.kt
+import io.exoquery.printing.pl
+
+object InvalidCapturedFunctionReqGoldenDynamic: MessageSpecFile {
+  override val messages = mapOf<String, GoldenResult>(
+    "error if captured function is not a SqlQuery<T> or SqlExpression<T>" to pl(
+      """
+      [ExoQuery] Could not understand an expression or query due to an error: The SqlFragment had the wrong kind of return type. A function annotated with @SqlFunction must return a single, single SqlQuery<T> or SqlExpression<T> instance.
+      ------------ Source ------------
+      fun externalFunction(name: String) = name + "_suffix"
+      ------------ Raw Expression ------------
+      @SqlFragment
+      fun externalFunction(name: String): String {
+        return name.plus(other = "_suffix")
+      }
+      [ExoQuery] Could not understand an expression or query due to an error: Could not parse the expression.
+      ------------ Source ------------
+      externalFunction(p.name)
+      ------------ Raw Expression ------------
+      externalFunction(name = p.<get-name>())
+      
+      """
+    ),
+    "error if captured function is not a SqlQuery<T> or SqlExpression<T> - with details" to pl(
+      """
+      [ExoQuery] Could not understand an expression or query due to an error: The SqlFragment had the wrong kind of return type. A function annotated with @SqlFunction must return a single, single SqlQuery<T> or SqlExpression<T> instance.
+      ------------ Source ------------
+      fun externalFunction(name: String) = name + "_suffix"
+      ------------ Raw Expression ------------
+      @SqlFragment
+      fun externalFunction(name: String): String {
+        return name.plus(other = "_suffix")
+      }
+      ------------ Raw Expression Tree ------------
+      [IrSimpleFunction] externalFunction ret:kotlin.String
+        [IrValueParameter] kind:Regular name:name index:0 type:kotlin.String
+        annotations:
+          SqlFragment
+        [IrBlockBody]
+          [IrReturn] type=kotlin.Nothing from='public final fun externalFunction (name: kotlin.String): kotlin.String declared in <root>'
+            [IrCall] public final fun plus (other: kotlin.Any?): kotlin.String [operator] declared in kotlin.String
+              <this>: [IrGetValue] 'name: kotlin.String declared in <root>.externalFunction' type=kotlin.String origin=null
+              other: [IrConst] String type=kotlin.String value="_"
+      
+      ----------------- Stack Trace: -----------------
+      [Excluding 10 lines]
+      ... (truncated)
+      [ExoQuery] Could not understand an expression or query due to an error: The SqlFragment had the wrong kind of return type. A function annotated with @SqlFunction must return a single, single SqlQuery<T> or SqlExpression<T> instance.
+      ------------ Source ------------
+      fun externalFunction(name: String) = name + "_suffix"
+      ------------ Raw Expression ------------
+      @SqlFragment
+      fun externalFunction(name: String): String {
+        return name.plus(other = "_suffix")
+      }
+      ------------ Raw Expression Tree ------------
+      [IrSimpleFunction] externalFunction ret:kotlin.String
+        [IrValueParameter] kind:Regular name:name index:0 type:kotlin.String
+        annotations:
+          SqlFragment
+        [IrBlockBody]
+          [IrReturn] type=kotlin.Nothing from='public final fun externalFunction (name: kotlin.String): kotlin.String declared in <root>'
+            [IrCall] public final fun plus (other: kotlin.Any?): kotlin.String [operator] declared in kotlin.String
+              <this>: [IrGetValue] 'name: kotlin.String declared in <root>.externalFunction' type=kotlin.String origin=null
+              other: [IrConst] String type=kotlin.String value="_"
+      
+      ----------------- Stack Trace: -----------------
+      [Excluding 10 lines]
+      ... (truncated)
+      [ExoQuery] Could not understand an expression or query due to an error: Could not parse the expression.
+      ------------ Source ------------
+      externalFunction(p.name)
+      ------------ Raw Expression ------------
+      externalFunction(name = p.<get-name>())
+      ------------ Raw Expression Tree ------------
+      [IrCall] public final fun externalFunction (name: kotlin.String): kotlin.String declared in <root>
+        name: [IrCall] public final fun <get-name> (): kotlin.String declared in <root>.MyPerson
+          <this>: [IrGetValue] 'p: <root>.MyPerson declared in <root>.run.<anonymous>.<anonymous>' type=<root>.MyPerson origin=null
+      
+      ----------------- Stack Trace: -----------------
+      [Excluding 10 lines]
+      ... (truncated)
+      
+      """
+    ),
+  )
+}

--- a/testing-compile/src/test/kotlin/io/exoquery/PluginCompileReqGoldenDynamic.kt
+++ b/testing-compile/src/test/kotlin/io/exoquery/PluginCompileReqGoldenDynamic.kt
@@ -9,7 +9,7 @@ object PluginCompileReqGoldenDynamic: MessageSpecFile {
   override val messages = mapOf<String, GoldenResult>(
     "should report error parsing external function" to pl(
       """
-      [ExoQuery] Could not understand an expression or query due to an error: Could not parse the expression.
+      [ExoQuery] Could not understand an expression or query due to an error: Could not parse the expression
       It looks like you are attempting to call the external function `externalFunction` in a captured block
       only functions specifically made to be interpreted by the ExoQuery system are allowed inside
       of captured blocks. If you are trying to use a runtime-value of a primitive, you need to bring
@@ -62,7 +62,7 @@ object PluginCompileReqGoldenDynamic: MessageSpecFile {
     ),
     "should report error parsing external function - error details enabled" to pl(
       """
-      [ExoQuery] Could not understand an expression or query due to an error: Could not parse the expression.
+      [ExoQuery] Could not understand an expression or query due to an error: Could not parse the expression
       It looks like you are attempting to call the external function `externalFunction` in a captured block
       only functions specifically made to be interpreted by the ExoQuery system are allowed inside
       of captured blocks. If you are trying to use a runtime-value of a primitive, you need to bring
@@ -88,6 +88,7 @@ object PluginCompileReqGoldenDynamic: MessageSpecFile {
       [IrCall] public final fun externalFunction (name: kotlin.String): kotlin.String declared in sample
         name: [IrCall] public final fun <get-name> (): kotlin.String declared in sample.MyPerson
           <this>: [IrGetValue] 'p: sample.MyPerson declared in sample.run.<anonymous>.<anonymous>' type=sample.MyPerson origin=null
+      
       ----------------- Stack Trace: -----------------
       [Excluding 10 lines]
       ... (truncated)
@@ -96,7 +97,7 @@ object PluginCompileReqGoldenDynamic: MessageSpecFile {
     ),
     "should report error parsing external function - error details enabled, custom stack count" to pl(
       """
-      [ExoQuery] Could not understand an expression or query due to an error: Could not parse the expression.
+      [ExoQuery] Could not understand an expression or query due to an error: Could not parse the expression
       It looks like you are attempting to call the external function `externalFunction` in a captured block
       only functions specifically made to be interpreted by the ExoQuery system are allowed inside
       of captured blocks. If you are trying to use a runtime-value of a primitive, you need to bring
@@ -122,6 +123,7 @@ object PluginCompileReqGoldenDynamic: MessageSpecFile {
       [IrCall] public final fun externalFunction (name: kotlin.String): kotlin.String declared in sample
         name: [IrCall] public final fun <get-name> (): kotlin.String declared in sample.MyPerson
           <this>: [IrGetValue] 'p: sample.MyPerson declared in sample.run.<anonymous>.<anonymous>' type=sample.MyPerson origin=null
+      
       ----------------- Stack Trace: -----------------
       [Excluding 5 lines]
       ... (truncated)


### PR DESCRIPTION
A Captured Function is traversed at least twice, once during the VisitTransformExpressions phase and potentially once again during the bubble-up traversal of the TransformAnnotatedFunction phase. Both of these call-chains eventually end up detecting that the Captured Function has an invalid return type and report errors. 

Previously, the locations reported on on the two were different (one was the location of the function, the other was the location of the function call). This was because `ScopedRunner.run` inside VisitTransformExpressions use a CompileLogger.error which use the transformation-element site (called the `macroInvokeSite`) as opposed to the actual element being errored as the location. To this solved the problem:
```kotlin
scopeContext.logger.error(e.fullMessageWithStackTrace(), e.location ?: expression.location(scopeContext.currentFile.fileEntry))
```

Note that this deduping will work so long as no stack-trace reported in the error. If something like @ErrorDetailsEnabled is used then VisitTransformExpressions and TransformAnnotatedFunction phase exceptions will have different stack traces because because the transformations are hitting the same IrFunction differently. This is expected and understood. For example
```
// From TransformAnnotatedFunction:
[ExoQuery] Could not understand an expression or query due to an error: The SqlFragment had the wrong kind of return type
...
----------------- Stack Trace: -----------------
at io.exoquery.ParseErrorCompanion.withFullMsg(ParseError.kt:84)
at io.exoquery.ParseErrorKt.parseError(ParseError.kt:129)
at io.exoquery.ParseErrorKt.parseErrordefault(ParseError.kt:128)
at io.exoquery.plugin.transform.TransformAnnotatedFunction.transform(TransformAnnotatedFunction.kt:125)
at io.exoquery.plugin.transform.TransformScaffoldAnnotatedFunctionCall.transform(TransformScaffoldAnnotatedFunctionCall.kt:75)
at io.exoquery.plugin.transform.VisitTransformExpressions.visitCalllambda1(VisitTransformExpressions.kt:256)
at io.exoquery.plugin.transform.VisitTransformExpressionsScopedRunner.runlambda0runBlock(VisitTransformExpressions.kt:174)
at io.exoquery.plugin.transform.VisitTransformExpressionsScopedRunner.run(VisitTransformExpressions.kt:177)
at io.exoquery.plugin.transform.VisitTransformExpressions.visitCall(VisitTransformExpressions.kt:254)
at io.exoquery.plugin.transform.VisitTransformExpressions.visitCall(VisitTransformExpressions.kt:38)
... (truncated)

// From VisitTransformExpressions:
[ExoQuery] Could not understand an expression or query due to an error: The SqlFragment had the wrong kind of return type
...
----------------- Stack Trace: -----------------
at io.exoquery.ParseErrorCompanion.withFullMsg(ParseError.kt:84)
at io.exoquery.ParseErrorKt.parseError(ParseError.kt:129)
at io.exoquery.ParseErrorKt.parseErrordefault(ParseError.kt:128)
at io.exoquery.plugin.trees.ParseExpression.parse(ParseExpression.kt:567)
at io.exoquery.plugin.trees.ParseExpressionparseinlinedthenThis19.invoke(ThenPattern1.kt:148)
at io.decomat.StageCase.eval(Matching.kt:68)
at io.decomat.DoMatch.match(Matching.kt:29)
at io.exoquery.plugin.trees.ParseExpression.parse(ParseExpression.kt:115)
at io.exoquery.plugin.trees.ParseExpressionparseFunctionBlockBodyinlinedthen1.invoke(ThenPattern1.kt:147)
at io.decomat.StageCase.eval(Matching.kt:68)
... (truncated)
```
