### PR TITLE
Improve JVM BigDecimal handling

### DIFF
--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlIdiom.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlIdiom.kt
@@ -219,6 +219,7 @@ interface SqlIdiom : HasPhasePrinting {
       "toDouble" -> +"CAST(${head.token} AS DOUBLE PRECISION)"
       "toFloat" -> +"CAST(${head.token} AS REAL)"
       "toBoolean" -> +"CAST(${head.token} AS BOOLEAN)"
+      "toBigDecimal" -> +"CAST(${head.token} AS DECIMAL)"
       "toString" -> +"${head.token}"
       else -> throw IllegalArgumentException("Unknown conversion function: ${name}")
     }
@@ -234,6 +235,7 @@ interface SqlIdiom : HasPhasePrinting {
       name == "toFloat" && !isKotlinSynthetic -> +"CAST(${head.token} AS REAL)"
       name == "toBoolean" -> +"CAST(${head.token} AS BOOLEAN)"
       name == "toString" -> +"CAST(${head.token} AS ${varcharType()})"
+      name == "toBigDecimal" -> +"CAST(${head.token} AS DECIMAL)"
       // toInt, toLong, toShort reply in implicit casting
       else -> +"${head.token}"
     }
@@ -247,7 +249,7 @@ interface SqlIdiom : HasPhasePrinting {
       name == "toShort" && !isKotlinSynthetic -> +"CAST(${head.token} AS SMALLINT)"
       name == "toBoolean" -> +"CAST(${head.token} AS BOOLEAN)"
       name == "toString" -> +"CAST(${head.token} AS ${varcharType()})"
-      // toFloat, toDouble reply in implicit casting
+      // toFloat, toDouble, toBigDecimal reply in implicit casting
       else -> +"${head.token}"
     }
   }
@@ -255,7 +257,6 @@ interface SqlIdiom : HasPhasePrinting {
   // Certain dialects require varchar sizes so allow this to be overridden
   fun varcharType(): Token = "VARCHAR".token
 
-  // TODO needs lots of refinement
   val XR.MethodCall.token
     get(): Token = run {
       val argsToken = (listOf(head) + args).map { it -> it.token }.mkStmt()

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/XROps.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/XROps.kt
@@ -365,6 +365,7 @@ object CID {
   val kotlin_Boolean = XR.ClassId("kotlin.Boolean")
   val exoquery_SqlQuery = XR.ClassId("io.exoquery.SqlQuery")
   val exoquery_Params = XR.ClassId("io.exoquery.Params")
+  val java_BigDecimal = XR.ClassId("java.math.BigDecimal")
 }
 
 fun XR.ClassId.isSqlQuery(): Boolean =
@@ -384,19 +385,19 @@ fun XR.ClassId.isWholeNumber(): Boolean =
 
 fun XR.ClassId.isFloatingPoint(): Boolean =
   when (this) {
-    CID.kotlin_Double, CID.kotlin_Float -> true
+    CID.kotlin_Double, CID.kotlin_Float, CID.java_BigDecimal -> true
     else -> false
   }
 
 fun XR.ClassId.isNumeric(): Boolean =
   when (this) {
-    CID.kotlin_Int, CID.kotlin_Long, CID.kotlin_Short, CID.kotlin_Double, CID.kotlin_Float -> true
+    CID.kotlin_Int, CID.kotlin_Long, CID.kotlin_Short, CID.kotlin_Double, CID.kotlin_Float, CID.java_BigDecimal -> true
     else -> false
   }
 
 fun String.isConverterFunction(): Boolean =
   when (this) {
-    "toLong", "toInt", "toShort", "toDouble", "toFloat", "toBoolean", "toString" -> true
+    "toLong", "toInt", "toShort", "toDouble", "toFloat", "toBoolean", "toString", "toBigDecimal" -> true
     else -> false
   }
 

--- a/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/jdbc/postgres/CastingSpec.kt
+++ b/exoquery-runner-jdbc/src/test/kotlin/io/exoquery/jdbc/postgres/CastingSpec.kt
@@ -4,7 +4,11 @@ import io.exoquery.jdbc.TestDatabases
 import io.exoquery.sql
 import io.exoquery.runOn
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.bigdecimal.shouldBeEqualIgnoringScale
 import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import java.math.BigDecimal
 
 class CastingSpec : FreeSpec({
   val ctx = TestDatabases.postgres
@@ -12,6 +16,22 @@ class CastingSpec : FreeSpec({
   "Int to String" {
     val q = sql.select { 1.toString() }
     q.buildFor.Postgres().runOn(ctx).first() shouldBe "1"
+  }
+
+  @Serializable
+  data class Wrapper(@Contextual val value: BigDecimal)
+
+  "Int to BigDecimal" {
+    val q = sql.select { Wrapper(1.toBigDecimal()) }
+    q.buildFor.Postgres().runOn(ctx).first().value shouldBeEqualIgnoringScale BigDecimal(1)
+  }
+  "Float to BigDecimal" {
+    val q = sql.select { Wrapper(1.1f.toBigDecimal()) }
+    q.buildFor.Postgres().runOn(ctx).first().value shouldBeEqualIgnoringScale BigDecimal("1.1")
+  }
+  "Double to BigDecimal" {
+    val q = sql.select { Wrapper(1.1.toBigDecimal()) }
+    q.buildFor.Postgres().runOn(ctx).first().value shouldBeEqualIgnoringScale BigDecimal("1.1")
   }
 
   "String to Long" {


### PR DESCRIPTION
This pull request adds support for converting values to `BigDecimal` in SQL queries and updates type handling to recognize `BigDecimal` as a numeric and floating-point type. It also introduces new tests to verify correct casting of various types to `BigDecimal` in PostgreSQL queries.

### BigDecimal support in SQL conversion functions
* Added handling for the `toBigDecimal` conversion function in `SqlIdiom`, generating appropriate SQL `CAST(... AS DECIMAL)` statements for different contexts. [[1]](diffhunk://#diff-e390e3d419a88533824250c73ae529e46e75bfc312dd3812375dda0035117cb3R222) [[2]](diffhunk://#diff-e390e3d419a88533824250c73ae529e46e75bfc312dd3812375dda0035117cb3R238)
* Updated comments and logic to include `toBigDecimal` among functions that rely on implicit casting.

### Type system enhancements
* Registered `java.math.BigDecimal` as a known class ID and updated type checks (`isFloatingPoint`, `isNumeric`) to treat `BigDecimal` as both numeric and floating-point. [[1]](diffhunk://#diff-a5dccf9c890aa1621e3ee0f7e26409c9a545aab795efd3bc95cb0d57efeb5205R368) [[2]](diffhunk://#diff-a5dccf9c890aa1621e3ee0f7e26409c9a545aab795efd3bc95cb0d57efeb5205L387-R400)
* Added `toBigDecimal` to the list of recognized converter functions.

### Testing improvements
* Added new tests in `CastingSpec` to verify casting from `Int`, `Float`, and `Double` to `BigDecimal`, ensuring correct behavior and SQL generation.
* Imported necessary libraries for `BigDecimal` testing and serialization.