### PR TITLE
Add JSON ops for SQL formatter

### DIFF
--- a/exoquery-engine/src/jvmMain/kotlin/io/exoquery/util/FormatQuery.kt
+++ b/exoquery-engine/src/jvmMain/kotlin/io/exoquery/util/FormatQuery.kt
@@ -3,4 +3,6 @@ package io.exoquery.util
 import com.github.vertical_blank.sqlformatter.SqlFormatter
 
 actual fun formatQuery(query: String): String =
-  SqlFormatter.format(query)
+  SqlFormatter
+    .extend { cfg -> cfg.plusOperators("->", "->>") }
+    .format(query)

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCompileQuery.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/transform/TransformCompileQuery.kt
@@ -116,7 +116,9 @@ class TransformCompileQuery(val superTransformer: VisitTransformExpressions) : T
               parseError("The query could not be rendered: ${e.message}\n------------------\n${xr.showRaw()}", expr)
             }
           if (isPretty)
-            SqlFormatter.format(queryStringRaw)
+            SqlFormatter
+              .extend { cfg -> cfg.plusOperators("->", "->>") }
+              .format(queryStringRaw)
           else
             queryStringRaw
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # ---- The ExoQuery plugin version that will be released! ----
-pluginVersion    = "2.0.0.PL"
+pluginVersion    = "2.0.0.PL.9"
 # ---- The Terpal Controller Version ----
 controller       = "4.4.0"
 # ---- All the other versions used ----

--- a/testing/src/jvmMain/kotlin/io/exoquery/FormatQueryExample.kt
+++ b/testing/src/jvmMain/kotlin/io/exoquery/FormatQueryExample.kt
@@ -1,0 +1,24 @@
+package io.exoquery
+
+import com.github.vertical_blank.sqlformatter.SqlFormatter
+
+fun main() {
+  val myQuery =
+    """
+      SELECT
+        ship.name AS first,
+        ship.specs ->> 'engine_type' AS second,
+        CAST(ship.specs ->> 'max_speed' AS DOUBLE PRECISION) AS third
+      FROM
+        Spacecraft ship
+      WHERE
+        CAST(ship.specs ->> 'max_speed' AS DOUBLE PRECISION) > 1200.0
+    """.trimIndent()
+
+  val query =
+    SqlFormatter
+      .extend { cfg -> cfg.plusOperators("->", "->>") }
+      .format(myQuery)
+
+  println("=================== My Query ==================\n${query}")
+}


### PR DESCRIPTION
This pull request updates the SQL formatting logic to support custom operators and introduces a new example for formatting queries using these operators. The main changes focus on enhancing the handling of SQL queries that use the `->` and `->>` operators, commonly used for JSON fields.

In the future we will want dialect-specific formatting (which the vertical-blank formatter supports) but that will require move involved changes. For now it is just sufficient to add common JSON operators.