### PR TITLE
Fix countDistinct in sql.select clauses

### DIFF
--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlIdiom.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/lang/SqlIdiom.kt
@@ -358,7 +358,7 @@ interface SqlIdiom : HasPhasePrinting {
       when {
         this.name == XR.FqName.Cast && args.size == 1 -> argsToken
         this.name.name == "COUNT_STAR" -> +"count(*)"
-        this.name == XR.FqName.CountDistinct -> +"count(DISTINCT ${argsToken})"
+        this.name == XR.FqName.CountDistinctCap || this.name == XR.FqName.CountDistinctSelect -> +"count(DISTINCT ${argsToken})"
         this.name == XR.FqName.JsonExtractAsString -> jsonExtractAsString(args[0], args[1])
         this.name == XR.FqName.JsonExtract -> jsonExtract(args[0], args[1])
         else -> {

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/XR.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/xr/XR.kt
@@ -249,7 +249,8 @@ sealed interface XR {
 
       val Empty = FqName(listOf())
       val Cast = FqName(listOf("kotlinCast"))
-      val CountDistinct = FqName("io.exoquery.CapturedBlock.countDistinct")
+      val CountDistinctCap = FqName("io.exoquery.CapturedBlock.countDistinct")
+      val CountDistinctSelect = FqName("io.exoquery.SelectClauseCapturedBlock.countDistinct")
 
       val JsonExtract = FqName(listOf(Globals.JsonExtractFunctionName))
       val JsonExtractAsString = FqName(listOf(Globals.JsonExtractAsStringFunctionName))

--- a/testing/src/commonTest/kotlin/io/exoquery/QueryReq.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/QueryReq.kt
@@ -120,8 +120,24 @@ class QueryReq: GoldenSpecDynamic(QueryReqGoldenDynamic, Mode.ExoGoldenTest(), {
     shouldBeGolden(people.xr, "XR")
     shouldBeGolden(people.build<PostgresDialect>())
   }
+  "select with distinct count" {
+    val people = sql.select {
+      val p = from(Table<Person>())
+      countDistinct(p.name, p.age)
+    }
+    shouldBeGolden(people.xr, "XR")
+    shouldBeGolden(people.build<PostgresDialect>())
+  }
   "map with stddev" {
     val people = sql { Table<Person>().map { p -> stddev(p.age) } }
+    shouldBeGolden(people.xr, "XR")
+    shouldBeGolden(people.build<PostgresDialect>())
+  }
+  "select with stdev and another column" {
+    val people = sql.select {
+      val p = from(Table<Person>())
+      stddev(p.age) to p.name
+    }
     shouldBeGolden(people.xr, "XR")
     shouldBeGolden(people.build<PostgresDialect>())
   }

--- a/testing/src/commonTest/kotlin/io/exoquery/QueryReqGoldenDynamic.kt
+++ b/testing/src/commonTest/kotlin/io/exoquery/QueryReqGoldenDynamic.kt
@@ -90,11 +90,23 @@ object QueryReqGoldenDynamic: GoldenQueryFile {
     "map with count distinct" to cr(
       "SELECT count(DISTINCT p.name, p.age) AS value FROM Person p"
     ),
+    "select with distinct count/XR" to kt(
+      "select { val p = from(Table(Person)); countDistinct_GC(p.name, p.age) }"
+    ),
+    "select with distinct count" to cr(
+      "SELECT count(DISTINCT p.name, p.age) AS value FROM Person p"
+    ),
     "map with stddev/XR" to kt(
       "Table(Person).map { p -> stddev_GC(p.age) }"
     ),
     "map with stddev" to cr(
       "SELECT stddev(p.age) AS value FROM Person p"
+    ),
+    "select with stdev and another column/XR" to kt(
+      "select { val p = from(Table(Person)); Tuple(first = stddev_GC(p.age), second = p.name) }"
+    ),
+    "select with stdev and another column" to cr(
+      "SELECT stddev(p.age) AS first, p.name AS second FROM Person p"
     ),
     "query with filter/XR" to kt(
       "Table(Person).filter { p -> p.age > 18 }"


### PR DESCRIPTION
Based on the fix for `countDistinct`, here's a PR comment:

---

## Fix `countDistinct()` SQL Generation in `sql.select` Blocks

### Problem
`countDistinct()` was generating incorrect SQL when used in `sql.select` blocks. 

**Before (Incorrect):**
```kotlin
val distinctNames = sql.select {
  val p = from(Table<Person>())
  countDistinct(p.name)
}
// Generated: SELECT countDistinct(p.name) FROM Person p  ❌ Wrong!
```


**After (Correct):**
```kotlin
val distinctNames = sql.select {
  val p = from(Table<Person>())
  countDistinct(p.name)
}
// Generates: SELECT COUNT(DISTINCT p.name) FROM Person p  ✅ Correct!
```


### Solution
Fixed the SQL generation for `countDistinct()` to properly handle both single-column and multi-column cases within `sql.select` blocks, ensuring it produces the correct `COUNT(DISTINCT ...)` SQL syntax.
