### PR TITLE
Have @ExoEntity imply @Serializable, integrate with IDE database tools

### DIFF
--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/UserAnnotations.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/UserAnnotations.kt
@@ -55,7 +55,10 @@ annotation class ExoField(val name: String)
 @MetaSerializable
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
-annotation class ExoEntity(@Language(value = "SQL", prefix = "SELECT * FROM \"", suffix = "\"") val name: String)
+annotation class ExoEntity(
+    // language=none
+    @Language(value = "SQL", prefix = "SELECT * FROM \"", suffix = "\"") val name: String = "" // empty string indicates Serializable alias
+)
 
 @Target(AnnotationTarget.TYPE, AnnotationTarget.FUNCTION, AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.LOCAL_VARIABLE)
 @Retention(AnnotationRetention.BINARY)

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/UserAnnotations.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/UserAnnotations.kt
@@ -1,5 +1,6 @@
 package io.exoquery
 
+import kotlinx.serialization.MetaSerializable
 import org.intellij.lang.annotations.Language
 
 
@@ -51,6 +52,7 @@ annotation class ExoValue
 @Retention(AnnotationRetention.BINARY)
 annotation class ExoField(val name: String)
 
+@MetaSerializable
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
 annotation class ExoEntity(@Language(value = "SQL", prefix = "SELECT * FROM \"", suffix = "\"") val name: String)

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/UserAnnotations.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/UserAnnotations.kt
@@ -52,6 +52,12 @@ annotation class ExoValue
 @Retention(AnnotationRetention.BINARY)
 annotation class ExoField(val name: String)
 
+/**
+ * Marks the data class as [kotlinx.serialization.Serializable].
+ * Optionally overrides the table used when generating queries for this class
+ *
+ * @param name the table to use in queries
+ **/
 @MetaSerializable
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)

--- a/exoquery-engine/src/commonMain/kotlin/io/exoquery/UserAnnotations.kt
+++ b/exoquery-engine/src/commonMain/kotlin/io/exoquery/UserAnnotations.kt
@@ -1,5 +1,7 @@
 package io.exoquery
 
+import org.intellij.lang.annotations.Language
+
 
 /**
  * Used to annotate a type so that the ExoQuery system knows that it is a value (i.e. a value-XRType)
@@ -51,7 +53,7 @@ annotation class ExoField(val name: String)
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
-annotation class ExoEntity(val name: String)
+annotation class ExoEntity(@Language(value = "SQL", prefix = "SELECT * FROM \"", suffix = "\"") val name: String)
 
 @Target(AnnotationTarget.TYPE, AnnotationTarget.FUNCTION, AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.LOCAL_VARIABLE)
 @Retention(AnnotationRetention.BINARY)

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/CompileExtensionsKotSerial.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/CompileExtensionsKotSerial.kt
@@ -84,14 +84,17 @@ fun IrType.inferSerializerForPropertyType() = run {
   // If there is a serializer defined on the class, try to get it
   val serializerFromTypeOrClass =
     serializerFromType
-      ?: propertyType.classOrNull?.owner?.getAnnotation<kotlinx.serialization.Serializable>()?.let { annotationCtor ->
-        // Note that the despite the fact that `kotlinx.serialization.Serializable` has a default 1st argument (i.e. the `with`)
-        // in the backend-IR when the argument is not explicitly specified on the type that is being annotated, there will be
-        // zero args that show up in the `valueArguments` field. I believe this is by design so that the compiler-writer can
-        // tell the serialization constructor (or any constructor for that matter) is being used with default values.
-        val serializerArg = annotationCtor.regularArgs.firstOrNull()
-        val serializerArgRef = serializerArg?.let { it as? IrClassReference }?.let { KnownSerializer.Ref(it) }
-        serializerArgRef ?: KnownSerializer.Implicit
+      ?: propertyType.classOrNull?.owner?.let { owner ->
+        owner.getAnnotation<kotlinx.serialization.Serializable>()?.let { annotationCtor ->
+          // Note that the despite the fact that `kotlinx.serialization.Serializable` has a default 1st argument (i.e. the `with`)
+          // in the backend-IR when the argument is not explicitly specified on the type that is being annotated, there will be
+          // zero args that show up in the `valueArguments` field. I believe this is by design so that the compiler-writer can
+          // tell the serialization constructor (or any constructor for that matter) is being used with default values.
+          val serializerArg = annotationCtor.regularArgs.firstOrNull()
+          val serializerArgRef = serializerArg?.let { it as? IrClassReference }?.let { KnownSerializer.Ref(it) }
+          serializerArgRef ?: KnownSerializer.Implicit
+        }
+          ?: KnownSerializer.Implicit.takeIf { owner.hasAnnotation<io.exoquery.ExoEntity>() }
       }
 
   serializerFromTypeOrClass ?: KnownSerializer.None

--- a/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/Extractors.kt
+++ b/exoquery-plugin-kotlin/src/main/kotlin/io/exoquery/plugin/trees/Extractors.kt
@@ -201,7 +201,7 @@ object Ir {
           val cls = it.classOrNull
           if (cls != null && cls.isDataClass()) {
             val (name, isRenamed) =
-              cls.owner.getAnnotationArgs<ExoEntity>().firstConstStringOrNull()?.let { it to true } // Try to get entity name from ExoEntity
+              cls.owner.getAnnotationArgs<ExoEntity>().firstConstStringOrNull()?.takeUnless { it.isEmpty() }?.let { it to true } // Try to get entity name from ExoEntity
                 ?: cls.owner.getAnnotationArgs<SerialName>().firstConstStringOrNull()?.let { it to true } // Then try SerialName from the class
                 ?: it.classFqName?.sanitizedClassName()?.let { it to false } // Then try the class fully-qualified name
                 ?: cls.safeName.let { it to false } // If all else fails, use the class symbol name

--- a/exoquery-runner-core/src/commonMain/kotlin/io/exoquery/testdata/Model.kt
+++ b/exoquery-runner-core/src/commonMain/kotlin/io/exoquery/testdata/Model.kt
@@ -14,26 +14,21 @@ value class PersonId(val value: Int)
 
 // TODO when I remove @Contextual terpal-sql says Bad value "Bloggs" for column of type int which means the cursor
 //      goes too far. Need to update terpal driver to handle value classes.
-@Serializable
 @ExoEntity("person")
 data class PersonWithIdCtx(@Contextual val id: PersonId, val firstName: String, val lastName: String, val age: Int)
 
-@Serializable
 @ExoEntity("person")
 data class PersonWithId(val id: PersonId, val firstName: String, val lastName: String, val age: Int)
 
-@Serializable
 @ExoEntity("person")
 data class PersonNullable(val id: Int, val firstName: String?, val lastName: String?, val age: Int?)
 
 @Serializable
 data class Address(val ownerId: Int, val street: String, val zip: Int)
 
-@Serializable
 @ExoEntity("address")
 data class AddressWithId(val ownerId: PersonId, val street: String, val zip: Int)
 
-@Serializable
 @ExoEntity("address")
 data class AddressWithIdCtx(val ownerId: PersonId, val street: String, val zip: Int)
 

--- a/exoquery-runner-core/src/commonMain/kotlin/io/exoquery/testdata/Model.kt
+++ b/exoquery-runner-core/src/commonMain/kotlin/io/exoquery/testdata/Model.kt
@@ -2,14 +2,13 @@ package io.exoquery.testdata
 
 import io.exoquery.ExoEntity
 import kotlinx.serialization.Contextual
-import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
-@Serializable
+@ExoEntity
 data class Person(val id: Int, val firstName: String, val lastName: String, val age: Int)
 
 @JvmInline
-@Serializable
+@ExoEntity
 value class PersonId(val value: Int)
 
 // TODO when I remove @Contextual terpal-sql says Bad value "Bloggs" for column of type int which means the cursor
@@ -23,7 +22,7 @@ data class PersonWithId(val id: PersonId, val firstName: String, val lastName: S
 @ExoEntity("person")
 data class PersonNullable(val id: Int, val firstName: String?, val lastName: String?, val age: Int?)
 
-@Serializable
+@ExoEntity
 data class Address(val ownerId: Int, val street: String, val zip: Int)
 
 @ExoEntity("address")
@@ -32,5 +31,5 @@ data class AddressWithId(val ownerId: PersonId, val street: String, val zip: Int
 @ExoEntity("address")
 data class AddressWithIdCtx(val ownerId: PersonId, val street: String, val zip: Int)
 
-@Serializable
+@ExoEntity
 data class Robot(val ownerId: Int, val model: String, val age: Int)


### PR DESCRIPTION
This is actually several suggestions regarding the same annotation (ExoEntity). I've split them into separate commits to reflect the individual suggestions.

I don't mind if you implement this yourself without merging or implement only a part of these, but I figured I'd at least offer code.

## IDE database integration for ExoEntity

59b036e adds a `@Language` annotation to `ExoEntity#value` annotation to enable IDE integration with the annotation.
This should simulate actual query usage of the given name. I noticed that names are always quoted in queries, so this is always quoted as well.

This enables:
* IDE database verification
* automatic refactoring by IDE database tools
* validity checking

<img width="878" height="431" alt="Image" src="https://github.com/user-attachments/assets/91747191-aa16-4fed-8725-30f6482cbfce" />
Here I linked a H2 database to PersonWithId.

## ExoEntity implies `@Serializable`
In every single example usage of ExoEntity, as well as every example I find in the codebase, this annotation is always accompanied by `@Serializable`.
### Add `@MetaSerializable` to ExoEntity
a1ee287 __lets you omit `@Serializable` entirely__ when using that annotation.

So instead of
```kotlin
@Serializable
@ExoEntity("address")
data class AddressWithId(val ownerId: PersonId, val street: String, val zip: Int)
```
You can write simply
```kotlin
@ExoEntity("address")
data class AddressWithId(val ownerId: PersonId, val street: String, val zip: Int)
```

#### Extension: Make `@ExoEntity` a true alias of Serializable
As an extension of the previous, d267581 makes `@Serializable` completely optional in all cases:

So instead of 
```kotlin
@Serializable
data class Address(val ownerId: Int, val street: String, val zip: Int)
```
You can write 
```kotlin
@ExoEntity
data class Address(val ownerId: Int, val street: String, val zip: Int)
```

#### Extension: Add a docstring to `@ExoEntity`
134ebdb just adds a docstring to `@ExoEntity`, not sure what else to say.

